### PR TITLE
lastfm: If artist name is included in tags, skip it.

### DIFF
--- a/plugins/lastfm.py
+++ b/plugins/lastfm.py
@@ -146,6 +146,12 @@ def getartisttags(artist, bot):
     request = requests.get(api_url, params = params)
     tags = request.json()
 
+    # Don't show tags from this list
+    blacklist = [
+    "seen live",
+    artist,
+    ]
+
     # if artist doesn't exist return no tags
     if tags.get("error") == 6:
         return "no tags"
@@ -153,7 +159,7 @@ def getartisttags(artist, bot):
     if 'tag' in tags['toptags']:
         for item in tags['toptags']['tag']:
             try:
-                if not item['name'] == "seen live":
+                if not item['name'] in blacklist:
                     tag_list.append(item['name'])
                 else:
                     pass


### PR DESCRIPTION
Similar to ignoring the "seen live" tag, this will not display the artist name if someone has tagged the artist with their own name.

This helps make sure all the tags are useful.

e.g.

`is listening to "Jude Law and a Semester Abroad" by Brand New from the album Your Favorite Weapon (Deluxe Edition) [playcount: 81] https://is.gd/imtPT9 (emo, Brand New, alternative, rock).`