### PR TITLE
Fix KICK syntax for .duckkick

### DIFF
--- a/plugins/duckhunt.py
+++ b/plugins/duckhunt.py
@@ -242,7 +242,7 @@ def bang(nick, chan, message, db, conn, notice):
         return "There is no activehunt right now. Use .starthunt to start a game."
     elif game_status[network][chan]['duck_status'] != 1:
         if game_status[network][chan]['no_duck_kick'] == 1:
-            out = "KICK {} {} There is no duck! What are you shooting at?".format(chan, nick)
+            out = "KICK {} {} :There is no duck! What are you shooting at?".format(chan, nick)
             conn.send(out)
             return
         return "There is no duck. What are you shooting at?"
@@ -297,7 +297,7 @@ def befriend(nick, chan, message, db, conn, notice):
         return "There is no hunt right now. Use .starthunt to start a game."
     elif game_status[network][chan]['duck_status'] != 1:
         if game_status[network][chan]['no_duck_kick'] == 1:
-            out = "KICK {} {} You tried befriending a non-existent duck, that's fucking creepy.".format(chan, nick)
+            out = "KICK {} {} :You tried befriending a non-existent duck, that's fucking creepy.".format(chan, nick)
             conn.send(out)
             return
         return "You tried befriending a non-existent duck, that's fucking creepy."


### PR DESCRIPTION
Some IRC servers (ngIRCd for example) require a : before the reason or give a syntax error