### PR TITLE
Allow specifying a message when parting a channel

### DIFF
--- a/cloudbot/clients/irc.py
+++ b/cloudbot/clients/irc.py
@@ -167,8 +167,11 @@ class IrcClient(Client):
         if channel not in self.channels:
             self.channels.append(channel)
 
-    def part(self, channel):
-        self.cmd("PART", channel)
+    def part(self, channel, message=None):
+        if message:
+            self.cmd("PART", channel, message)
+        else:
+            self.cmd("PART", channel)
         if channel in self.channels:
             self.channels.remove(channel)
 

--- a/plugins/admin_bot.py
+++ b/plugins/admin_bot.py
@@ -265,16 +265,20 @@ def part(text, conn, nick, message, chan, notice):
     :type chan: str
     """
     if text:
-        targets = text
+        split_text = text.split()
+        target = split_text[0]
+        if len(split_text) > 1:
+            message = ' '.join(text.split()[1:])
+        else:
+            message = ""
     else:
-        targets = chan
-    for target in targets.split():
-        if not target.startswith("#"):
-            target = "#{}".format(target)
-        if logchannel:
-            message("{} used PART to make me leave {}.".format(nick, target), logchannel)
-        notice("Attempting to leave {}...".format(target))
-        conn.part(target)
+        target = chan
+    if not target.startswith("#"):
+        target = "#{}".format(target)
+    if logchannel:
+        message("{} used PART to make me leave {}.".format(nick, target), logchannel)
+    notice("Attempting to leave {} with the following message: {}".format(target, message))
+    conn.part(target, message)
 
 
 @asyncio.coroutine


### PR DESCRIPTION
This REMOVES the ability to part multiple channels at once!

e.g. 

/msg MackenzieFoy part ##batcave Hello world!

MackenzieFoy: Attempting to leave ##batcave with message hello world
MackenzieFoy (snoopbott@user/rory/bot/SnoopBott) has left ##batcave (hello world)
