### PR TITLE
Consider nicks with ` characters to be valid for the purposes of food

### DIFF
--- a/plugins/foods.py
+++ b/plugins/foods.py
@@ -8,7 +8,7 @@ import re
 from cloudbot import hook
 from cloudbot.util import textgen
 
-nick_re = re.compile("^[A-Za-z0-9_|.\-\]\[\{\}\*]*$", re.I)
+nick_re = re.compile("^[A-Za-z0-9_|.\-\]\[\{\}\*\`]*$", re.I)
 
 cakes = ['Chocolate', 'Ice Cream', 'Angel', 'Boston Cream', 'Birthday', 'Bundt', 'Carrot', 'Coffee', 'Devils', 'Fruit',
          'Gingerbread', 'Pound', 'Red Velvet', 'Stack', 'Welsh', 'Yokan']


### PR DESCRIPTION
lord_shaxx|butts        .cake Blinke180AhChoo`
+gonzobot       (lord_shaxx|butts) I can't give a cake to that user.
Blinke180AhChoo`        Why can't the bot give me stuff?