### PR TITLE
Prevent speedtest links being announced

### DIFF
--- a/plugins/link_announcer.py
+++ b/plugins/link_announcer.py
@@ -5,7 +5,7 @@ from contextlib import closing
 from cloudbot import hook
 
 # This will match any URL except the patterns defined in blacklist.
-blacklist = '.*(reddit\.com|redd\.it|youtube\.com|youtu\.be|imdb\.com|spotify\.com|twitter\.com|twitch\.tv|amazon\.co|xkcd\.com|amzn\.co|steamcommunity\.com|steampowered\.com|newegg\.com|soundcloud\.com|vimeo\.com).*'
+blacklist = '.*(reddit\.com|redd\.it|youtube\.com|youtu\.be|imdb\.com|spotify\.com|twitter\.com|twitch\.tv|amazon\.co|xkcd\.com|amzn\.co|steamcommunity\.com|steampowered\.com|newegg\.com|soundcloud\.com|vimeo\.com|speedtest\.net).*'
 url_re = re.compile('(?!{})http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+~]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'.format(blacklist), re.I)
 
 opt_out = []


### PR DESCRIPTION
Speedtest is already handled by the speedtest plugin. No need to announce the (mostly useless) title too.