### PR TITLE
Add hook halting system and priorities

### DIFF
--- a/cloudbot/bot.py
+++ b/cloudbot/bot.py
@@ -304,12 +304,17 @@ class CloudBot:
             def regex_priority(t):
                 return t[1].priority
 
+            regex_matched = False
             for regex, regex_hook in sorted(self.plugin_manager.regex_hooks, key=regex_priority, reverse=True):
                 if not regex_hook.run_on_cmd and cmd_match:
                     continue
 
+                if regex_hook.only_no_match and regex_matched:
+                    continue
+
                 regex_match = regex.search(event.content)
                 if regex_match:
+                    regex_matched = True
                     regex_event = RegexEvent(hook=regex_hook, match=regex_match, base_event=event)
                     if not add_hook(regex_hook, regex_event):
                         # The hook has an action of Action.HALT* so stop adding new tasks

--- a/cloudbot/bot.py
+++ b/cloudbot/bot.py
@@ -5,6 +5,8 @@ import collections
 import re
 import os
 import gc
+from operator import not_, attrgetter, itemgetter
+
 from sqlalchemy import create_engine
 
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -14,6 +16,7 @@ from sqlalchemy.schema import MetaData
 import cloudbot
 from cloudbot.client import Client
 from cloudbot.config import Config
+from cloudbot.hook import Action
 from cloudbot.reloader import PluginReloader
 from cloudbot.plugin import PluginManager
 from cloudbot.event import Event, CommandEvent, RegexEvent, EventType
@@ -221,23 +224,46 @@ class CloudBot:
         run_before_tasks = []
         tasks = []
         command_prefix = event.conn.config.get('command_prefix', '.')
+        halted = False
+
+        def add_hook(hook, _event, _run_before=False):
+            nonlocal halted
+            if halted:
+                return False
+
+            coro = self.plugin_manager.launch(hook, _event)
+            if _run_before:
+                run_before_tasks.append(coro)
+            else:
+                tasks.append(coro)
+
+            if hook.action is Action.HALTALL:
+                halted = True
+                return False
+            elif hook.action is Action.HALTTYPE:
+                return False
+            return True
 
         # Raw IRC hook
         for raw_hook in self.plugin_manager.catch_all_triggers:
             # run catch-all coroutine hooks before all others - TODO: Make this a plugin argument
-            if not raw_hook.threaded:
-                run_before_tasks.append(
-                    self.plugin_manager.launch(raw_hook, Event(hook=raw_hook, base_event=event)))
-            else:
-                tasks.append(self.plugin_manager.launch(raw_hook, Event(hook=raw_hook, base_event=event)))
+            run_before = not raw_hook.threaded
+            if not add_hook(raw_hook, Event(hook=raw_hook, base_event=event), _run_before=run_before):
+                # The hook has an action of Action.HALT* so stop adding new tasks
+                break
+
         if event.irc_command in self.plugin_manager.raw_triggers:
             for raw_hook in self.plugin_manager.raw_triggers[event.irc_command]:
-                tasks.append(self.plugin_manager.launch(raw_hook, Event(hook=raw_hook, base_event=event)))
+                if not add_hook(raw_hook, Event(hook=raw_hook, base_event=event)):
+                    # The hook has an action of Action.HALT* so stop adding new tasks
+                    break
 
         # Event hooks
         if event.type in self.plugin_manager.event_type_hooks:
             for event_hook in self.plugin_manager.event_type_hooks[event.type]:
-                tasks.append(self.plugin_manager.launch(event_hook, Event(hook=event_hook, base_event=event)))
+                if not add_hook(event_hook, Event(hook=event_hook, base_event=event)):
+                    # The hook has an action of Action.HALT* so stop adding new tasks
+                    break
 
         if event.type is EventType.message:
             # Commands
@@ -258,7 +284,7 @@ class CloudBot:
                     command_hook = self.plugin_manager.commands[command]
                     command_event = CommandEvent(hook=command_hook, text=text,
                                                  triggered_command=command, base_event=event)
-                    tasks.append(self.plugin_manager.launch(command_hook, command_event))
+                    add_hook(command_hook, command_event)
                 else:
                     potential_matches = []
                     for potential_match, plugin in self.plugin_manager.commands.items():
@@ -269,20 +295,25 @@ class CloudBot:
                             command_hook = potential_matches[0][1]
                             command_event = CommandEvent(hook=command_hook, text=text,
                                                          triggered_command=command, base_event=event)
-                            tasks.append(self.plugin_manager.launch(command_hook, command_event))
+                            add_hook(command_hook, command_event)
                         else:
                             event.notice("Possible matches: {}".format(
                                 formatting.get_text_list([command for command, plugin in potential_matches])))
 
             # Regex hooks
-            for regex, regex_hook in self.plugin_manager.regex_hooks:
+            def regex_priority(t):
+                return t[1].priority
+
+            for regex, regex_hook in sorted(self.plugin_manager.regex_hooks, key=regex_priority, reverse=True):
                 if not regex_hook.run_on_cmd and cmd_match:
-                    pass
-                else:
-                    regex_match = regex.search(event.content)
-                    if regex_match:
-                        regex_event = RegexEvent(hook=regex_hook, match=regex_match, base_event=event)
-                        tasks.append(self.plugin_manager.launch(regex_hook, regex_event))
+                    continue
+
+                regex_match = regex.search(event.content)
+                if regex_match:
+                    regex_event = RegexEvent(hook=regex_hook, match=regex_match, base_event=event)
+                    if not add_hook(regex_hook, regex_event):
+                        # The hook has an action of Action.HALT* so stop adding new tasks
+                        break
 
         # Run the tasks
         yield from asyncio.gather(*run_before_tasks, loop=self.loop)

--- a/cloudbot/bot.py
+++ b/cloudbot/bot.py
@@ -5,6 +5,7 @@ import collections
 import re
 import os
 import gc
+from operator import attrgetter
 
 from sqlalchemy import create_engine
 
@@ -299,11 +300,8 @@ class CloudBot:
                                 formatting.get_text_list([command for command, plugin in potential_matches])))
 
             # Regex hooks
-            def regex_priority(t):
-                return t[1].priority
-
             regex_matched = False
-            for regex, regex_hook in sorted(self.plugin_manager.regex_hooks, key=regex_priority, reverse=True):
+            for regex, regex_hook in self.plugin_manager.regex_hooks:
                 if not regex_hook.run_on_cmd and cmd_match:
                     continue
 

--- a/cloudbot/bot.py
+++ b/cloudbot/bot.py
@@ -5,7 +5,6 @@ import collections
 import re
 import os
 import gc
-from operator import not_, attrgetter, itemgetter
 
 from sqlalchemy import create_engine
 
@@ -13,7 +12,6 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.schema import MetaData
 
-import cloudbot
 from cloudbot.client import Client
 from cloudbot.config import Config
 from cloudbot.hook import Action

--- a/cloudbot/hook.py
+++ b/cloudbot/hook.py
@@ -1,10 +1,28 @@
 import inspect
 import re
 import collections
+from enum import Enum, unique
 
 from cloudbot.event import EventType
 
 valid_command_re = re.compile(r"^\w+$")
+
+
+@unique
+class Priority(Enum):
+    LOWEST = -128
+    LOW = -64
+    NORMAL = 0
+    HIGH = 63
+    HIGHEST = 127
+
+
+@unique
+class Action(Enum):
+    """Defines the action to take after executing a hook"""
+    HALTTYPE = 0  # Once this hook executes, no other hook of that type should run
+    HALTALL = 1  # Once this hook executes, No other hook should run
+    CONTINUE = 2  # Normal execution of all hooks
 
 
 class _Hook:

--- a/cloudbot/hook.py
+++ b/cloudbot/hook.py
@@ -1,7 +1,7 @@
 import inspect
 import re
 import collections
-from enum import Enum, unique
+from enum import Enum, unique, IntEnum
 
 from cloudbot.event import EventType
 
@@ -9,7 +9,7 @@ valid_command_re = re.compile(r"^\w+$")
 
 
 @unique
-class Priority(Enum):
+class Priority(IntEnum):
     LOWEST = -128
     LOW = -64
     NORMAL = 0

--- a/cloudbot/hook.py
+++ b/cloudbot/hook.py
@@ -10,11 +10,12 @@ valid_command_re = re.compile(r"^\w+$")
 
 @unique
 class Priority(IntEnum):
-    LOWEST = -128
-    LOW = -64
+    # Reversed to maintain compatibility with sieve hooks numeric priority
+    LOWEST = 127
+    LOW = 63
     NORMAL = 0
-    HIGH = 63
-    HIGHEST = 127
+    HIGH = -64
+    HIGHEST = -128
 
 
 @unique

--- a/cloudbot/plugin.py
+++ b/cloudbot/plugin.py
@@ -653,6 +653,7 @@ class RegexHook(Hook):
         """
         self.run_on_cmd = regex_hook.kwargs.pop("run_on_cmd", False)
         self.priority = regex_hook.kwargs.pop("priority", Priority.NORMAL)
+        self.only_no_match = regex_hook.kwargs.pop("only_no_match", False)
 
         self.regexes = regex_hook.regexes
 

--- a/cloudbot/plugin.py
+++ b/cloudbot/plugin.py
@@ -228,8 +228,14 @@ class PluginManager:
             self.sieves.append(sieve_hook)
             self._log_hook(sieve_hook)
 
-        # sort sieve hooks by priority
-        self.sieves.sort(key=lambda x: x.priority)
+        # Sort hooks
+        self.regex_hooks.sort(key=lambda x: x[1].priority)
+        dicts_of_lists_of_hooks = (self.event_type_hooks, self.raw_triggers)
+        lists_of_hooks = [self.catch_all_triggers, self.sieves]
+        lists_of_hooks.extend(d.values() for d in dicts_of_lists_of_hooks)
+
+        for lst in lists_of_hooks:
+            lst.sort(key=lambda x: x.priority)
 
         # we don't need this anymore
         del plugin.run_on_start
@@ -596,6 +602,7 @@ class Hook:
         self.permissions = func_hook.kwargs.pop("permissions", [])
         self.single_thread = func_hook.kwargs.pop("singlethread", False)
         self.action = func_hook.kwargs.pop("action", Action.CONTINUE)
+        self.priority = func_hook.kwargs.pop("priority", Priority.NORMAL)
 
         if func_hook.kwargs:
             # we should have popped all the args, so warn if there are any left
@@ -652,7 +659,6 @@ class RegexHook(Hook):
         :type regex_hook: cloudbot.util.hook._RegexHook
         """
         self.run_on_cmd = regex_hook.kwargs.pop("run_on_cmd", False)
-        self.priority = regex_hook.kwargs.pop("priority", Priority.NORMAL)
         self.only_no_match = regex_hook.kwargs.pop("only_no_match", False)
 
         self.regexes = regex_hook.regexes

--- a/cloudbot/plugin.py
+++ b/cloudbot/plugin.py
@@ -5,6 +5,7 @@ import inspect
 import logging
 import os
 import re
+from itertools import chain
 
 import sqlalchemy
 
@@ -232,7 +233,7 @@ class PluginManager:
         self.regex_hooks.sort(key=lambda x: x[1].priority)
         dicts_of_lists_of_hooks = (self.event_type_hooks, self.raw_triggers)
         lists_of_hooks = [self.catch_all_triggers, self.sieves]
-        lists_of_hooks.extend(d.values() for d in dicts_of_lists_of_hooks)
+        lists_of_hooks.extend(chain.from_iterable(d.values() for d in dicts_of_lists_of_hooks))
 
         for lst in lists_of_hooks:
             lst.sort(key=lambda x: x.priority)

--- a/cloudbot/plugin.py
+++ b/cloudbot/plugin.py
@@ -9,6 +9,7 @@ import re
 import sqlalchemy
 
 from cloudbot.event import Event
+from cloudbot.hook import Priority, Action
 from cloudbot.util import database
 
 logger = logging.getLogger("cloudbot")
@@ -594,6 +595,7 @@ class Hook:
 
         self.permissions = func_hook.kwargs.pop("permissions", [])
         self.single_thread = func_hook.kwargs.pop("singlethread", False)
+        self.action = func_hook.kwargs.pop("action", Action.CONTINUE)
 
         if func_hook.kwargs:
             # we should have popped all the args, so warn if there are any left
@@ -650,6 +652,7 @@ class RegexHook(Hook):
         :type regex_hook: cloudbot.util.hook._RegexHook
         """
         self.run_on_cmd = regex_hook.kwargs.pop("run_on_cmd", False)
+        self.priority = regex_hook.kwargs.pop("priority", Priority.NORMAL)
 
         self.regexes = regex_hook.regexes
 

--- a/plugins/link_announcer.py
+++ b/plugins/link_announcer.py
@@ -4,17 +4,18 @@ from bs4 import BeautifulSoup
 from contextlib import closing
 from cloudbot import hook
 
-# This will match any URL except the patterns defined in blacklist.
-blacklist = '.*(reddit\.com|redd\.it|youtube\.com|youtu\.be|imdb\.com|spotify\.com|twitter\.com|twitch\.tv|amazon\.co|xkcd\.com|amzn\.co|steamcommunity\.com|steampowered\.com|newegg\.com|soundcloud\.com|vimeo\.com).*'
-url_re = re.compile('(?!{})http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+~]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'.format(blacklist), re.I)
+from cloudbot.hook import Priority, Action
+
+# This will match any URL, blacklist removed and abstracted to a priority/halting system
+url_re = re.compile(r'https?://(?:[a-zA-Z]|[0-9]|[$-_@.&+~]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', re.I)
 
 opt_out = []
 
 traditional = [
     (1024 ** 5, 'PB'),
-    (1024 ** 4, 'TB'), 
-    (1024 ** 3, 'GB'), 
-    (1024 ** 2, 'MB'), 
+    (1024 ** 4, 'TB'),
+    (1024 ** 3, 'GB'),
+    (1024 ** 2, 'MB'),
     (1024 ** 1, 'KB'),
     (1024 ** 0, 'B'),
     ]
@@ -29,7 +30,8 @@ def bytesto(bytes, system = traditional):
     amount = int(bytes/factor)
     return str(amount) + suffix
 
-@hook.regex(url_re)
+
+@hook.regex(url_re, priority=Priority.LOW, action=Action.HALTTYPE, only_no_match=True)
 def print_url_title(message, match, chan):
     if chan in opt_out:
         return


### PR DESCRIPTION
New hook args:
- `action` - Determines what action to take after this hook is matched, for instance:
  - `Action.HALTTYPE` - Will not run any hooks of the same type after the hook is matched
  - `Action.HALTALL` - Will not run any hooks of any type after the hook is matched
  - `Action.CONTINUE` - (Default) does not affect any other hooks after it is matched
- `priority` - Sets the priority of the hook to one of: `Priority.{LOWEST|LOW|NORMAL|HIGH|HIGHEST}`, determines the order in which they are called, providing a deterministic call order for `action`

##### _Note_: `priority` can be set to any arbitrary value that can be compared using relational operators with an `int`

New RegexHook args:
- `only_no_match` - Only run this hook is no hook of a higher priority matched

Changes to `link_announcer.py`:
- Removed blacklist regex
- Implemented new priority/halting system to allow a more dynamic blacklist

Fixes #69 and obsoletes #66 