### PR TITLE
Move channel autojoins to after the end of the MOTD

### DIFF
--- a/plugins/autojoin.py
+++ b/plugins/autojoin.py
@@ -20,7 +20,7 @@ def get_channels(db, conn):
 
 
 @asyncio.coroutine
-@hook.irc_raw('004')
+@hook.irc_raw('376')
 def do_joins(db, conn, async_call):
     chans = yield from async_call(get_channels, db, conn)
     join_throttle = conn.config.get("join_throttle", 0.4)

--- a/plugins/core/core_misc.py
+++ b/plugins/core/core_misc.py
@@ -69,7 +69,6 @@ def onjoin(conn, bot):
     :type conn: cloudbot.clients.clients.IrcClient
     :type bot: cloudbot.bot.CloudBot
     """
-    chans = copy(conn.channels)
     bot.logger.info("[{}|misc] Bot is sending join commands for network.".format(conn.name))
     nickserv = conn.config.get('nickserv')
     if nickserv and nickserv.get("enabled", True):
@@ -103,15 +102,21 @@ def onjoin(conn, bot):
         bot.logger.info("[{}|misc] Bot is setting mode on itself: {}".format(conn.name, mode))
         conn.cmd('MODE', conn.nick, mode)
 
+    conn.ready = True
+    bot.logger.info("[{}|misc] Bot has finished sending join commands for network.".format(conn.name))
+
+
+@asyncio.coroutine
+@hook.irc_raw('376')
+def do_joins(logger, conn):
+    chans = copy(conn.channels)
+
     # Join config-defined channels
     join_throttle = conn.config.get('join_throttle', 0.4)
-    bot.logger.info("[{}|misc] Bot is joining channels for network.".format(conn.name))
+    logger.info("[%s|misc] Bot is joining channels for network.", conn.name)
     for channel in chans:
         conn.join(channel)
         yield from asyncio.sleep(join_throttle)
-
-    conn.ready = True
-    bot.logger.info("[{}|misc] Bot has finished sending join commands for network.".format(conn.name))
 
 
 @asyncio.coroutine

--- a/plugins/core/core_misc.py
+++ b/plugins/core/core_misc.py
@@ -35,10 +35,9 @@ def check_mode(irc_paramlist, conn, message):
     #message(", ".join(irc_paramlist), "bloodygonzo")
     mode = irc_paramlist[2]
     require_reg = conn.config.get('require_registered_channels', False)
-    if not "r" in mode and conn.name == "snoonet" and require_reg:
+    if "r" not in mode and require_reg:
         message("I do not stay in unregistered channels", irc_paramlist[1])
-        out = "PART {}".format(irc_paramlist[1])
-        conn.send(out)
+        conn.part(irc_paramlist[1])
 
 
 @hook.irc_raw('MODE')


### PR DESCRIPTION
This avoids a race condition in chan_data where the `channel_modes` server info wouldn't be available yet, due to it being parsed from the `005` numeric and the joins starting on the `004`