### PR TITLE
Allow the Python 3.7 builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "3.5"
   - "3.6"
   - "3.7-dev"
+  - "nightly"
+  - "pypy3"
 
 cache: pip
 
@@ -21,3 +23,8 @@ after_success:
 env:
   - PYTHONPATH=.
   - PYTHONPATH=. PYTHONASYNCIODEBUG=1
+
+matrix:
+  allow_failures:
+    - python: "3.7-dev"
+    - python: "pypy3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,5 @@ env:
 matrix:
   allow_failures:
     - python: "3.7-dev"
+    - python: "nightly"
     - python: "pypy3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,3 @@ matrix:
   allow_failures:
     - python: "3.7-dev"
     - python: "nightly"
-    - python: "pypy3"


### PR DESCRIPTION
This allows experimental builds to fail without marking the entire build as failed