### PR TITLE
Fix valid end characters for link announcer regex

### DIFF
--- a/plugins/link_announcer.py
+++ b/plugins/link_announcer.py
@@ -33,16 +33,19 @@ url_re = re.compile(
     # Domain
     (?:
         # TODO Add support for IDNA hostnames as specified by RFC5891
-        [\-.0-9A-Za-z]+|  # host
-        \d{1,3}(?:\.\d{1,3}){3}|  # IPv4
-        \[[A-F0-9]{0,4}(?::[A-F0-9]{0,4}){2,7}\]  # IPv6
+        (?:
+            [\-.0-9A-Za-z]+|  # host
+            \d{1,3}(?:\.\d{1,3}){3}|  # IPv4
+            \[[A-F0-9]{0,4}(?::[A-F0-9]{0,4}){2,7}\]  # IPv6
+        )
+        (?<![.,?!\]])  # Invalid end chars
     )
     
     (?::\d*)?  # port
     
-    (?:/(?:""" + no_parens(PATH_SEG_CHARS) + r""")*)*(?<![.,?!\]])  # Path segment
+    (?:/(?:""" + no_parens(PATH_SEG_CHARS) + r""")*(?<![.,?!\]]))*  # Path segment
     
-    (?:\?(?:""" + no_parens(QUERY_CHARS) + r""")*(?<![.,?!\]]))?  # Query
+    (?:\?(?:""" + no_parens(QUERY_CHARS) + r""")*(?<![.,!\]]))?  # Query
     
     (?:\#(?:""" + no_parens(FRAG_CHARS) + r""")*(?<![.,?!\]]))?  # Fragment
     """,

--- a/tests/plugin_tests/test_link_announcer.py
+++ b/tests/plugin_tests/test_link_announcer.py
@@ -27,6 +27,8 @@ MATCHES = (
     "http://1337.net",
     "http://a.b-c.de",
     "http://223.255.255.254",
+    "https://foo.bar/baz?#",
+    "https://foo.bar/baz?",
 )
 
 FAILS = (
@@ -55,6 +57,8 @@ FAILS = (
     "https://foo.bar/baz.ext)",
     "https://foo.bar/test.",
     "https://foo.bar/test(test",
+    "https://foo.bar.",
+    "https://foo.bar./",
 )
 
 SEARCH = (


### PR DESCRIPTION
This makes sure the link announcer will match partial and empty query parameters, noticed this issue after #190 was merged.