### PR TITLE
Refactor hook launching system

### DIFF
--- a/cloudbot/event.py
+++ b/cloudbot/event.py
@@ -372,6 +372,12 @@ class Event:
         """
         return self.conn.is_nick_valid(nick)
 
+    def __getitem__(self, item):
+        try:
+            return getattr(self, item)
+        except AttributeError:
+            raise KeyError(item)
+
     if sys.version_info < (3, 7, 0):
         # noinspection PyCompatibility
         @asyncio.coroutine

--- a/cloudbot/util/async_util.py
+++ b/cloudbot/util/async_util.py
@@ -3,9 +3,10 @@ Wraps various asyncio functions
 """
 
 import asyncio
-
 import sys
 from functools import partial
+
+from cloudbot.util.func_utils import call_with_args
 
 
 def wrap_future(fut, *, loop=None):
@@ -31,6 +32,19 @@ def run_func(loop, func, *args, **kwargs):
         return (yield from part())
     else:
         return (yield from loop.run_in_executor(None, part))
+
+
+@asyncio.coroutine
+def run_func_with_args(loop, func, arg_data, executor=None):
+    if asyncio.iscoroutine(func):
+        raise TypeError('A coroutine function or a normal, non-async callable are required')
+
+    if asyncio.iscoroutinefunction(func):
+        coro = call_with_args(func, arg_data)
+    else:
+        coro = loop.run_in_executor(executor, call_with_args, func, arg_data)
+
+    return (yield from coro)
 
 
 def run_coroutine_threadsafe(coro, loop):

--- a/cloudbot/util/func_utils.py
+++ b/cloudbot/util/func_utils.py
@@ -3,11 +3,10 @@ import inspect
 
 class ParameterError(Exception):
     def __init__(self, name, valid_args):
-        self.name = name
-        self.valid_args = list(valid_args)
+        self.__init__(name, list(valid_args))
 
     def __str__(self):
-        return "'{}' is not a valid parameter, valid parameters are: {}".format(self.name, self.valid_args)
+        return "'{}' is not a valid parameter, valid parameters are: {}".format(self.args[0], self.args[1])
 
 
 def call_with_args(func, arg_data):

--- a/cloudbot/util/func_utils.py
+++ b/cloudbot/util/func_utils.py
@@ -1,7 +1,20 @@
 import inspect
 
 
+class ParameterError(Exception):
+    def __init__(self, name, valid_args):
+        self.name = name
+        self.valid_args = list(valid_args)
+
+    def __str__(self):
+        return "'{}' is not a valid parameter, valid parameters are: {}".format(self.name, self.valid_args)
+
+
 def call_with_args(func, arg_data):
     sig = inspect.signature(func)
-    args = [arg_data[key] for key in sig.parameters.keys() if not key.startswith('_')]
+    try:
+        args = [arg_data[key] for key in sig.parameters.keys() if not key.startswith('_')]
+    except KeyError as e:
+        raise ParameterError(e.args[0], arg_data.keys()) from e
+
     return func(*args)

--- a/cloudbot/util/func_utils.py
+++ b/cloudbot/util/func_utils.py
@@ -1,0 +1,7 @@
+import inspect
+
+
+def call_with_args(func, arg_data):
+    sig = inspect.signature(func)
+    args = [arg_data[key] for key in sig.parameters.keys() if not key.startswith('_')]
+    return func(*args)


### PR DESCRIPTION
This makes it easier for plugins to mimic the core hook launching functionality where an `Event` object can be expanded to the named parameters for a function.