### PR TITLE
Make .help respond with the used command prefix

### DIFF
--- a/cloudbot/bot.py
+++ b/cloudbot/bot.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import time
+from functools import partial
 from pathlib import Path
 
 from sqlalchemy import create_engine
@@ -14,7 +15,6 @@ from sqlalchemy.schema import MetaData
 from watchdog.observers import Observer
 
 from cloudbot.client import Client, CLIENTS
-from cloudbot.clients.irc import irc_clean
 from cloudbot.config import Config
 from cloudbot.event import Event, CommandEvent, RegexEvent, EventType
 from cloudbot.hook import Action
@@ -39,6 +39,29 @@ def clean_name(n):
     :rtype: str
     """
     return re.sub('[^A-Za-z0-9_]+', '', n.replace(" ", "_"))
+
+
+def get_cmd_regex(event):
+    conn = event.conn
+    is_pm = event.chan.lower() == event.nick.lower()
+    command_prefix = re.escape(conn.config.get('command_prefix', '.'))
+    conn_nick = re.escape(event.conn.nick)
+    cmd_re = re.compile(
+        r"""
+        ^
+        # Prefix or nick
+        (?:
+            (?P<prefix>[""" + command_prefix + r"""])""" + ('?' if is_pm else '') + r"""
+            |
+            """ + conn_nick + r"""[,;:]+\s+
+        )
+        (?P<command>\w+)  # Command
+        (?:$|\s+)
+        (?P<text>.*)     # Text
+        """,
+        re.IGNORECASE | re.VERBOSE
+    )
+    return cmd_re
 
 
 class CloudBot:
@@ -281,23 +304,18 @@ class CloudBot:
 
         if event.type is EventType.message:
             # Commands
-            if event.chan.lower() == event.nick.lower():  # private message, no command prefix
-                command_re = r'(?i)^(?:[{}]?|{}[,;:]+\s+)(\w+)(?:$|\s+)(.*)'
-            else:
-                command_re = r'(?i)^(?:[{}]|{}[,;:]+\s+)(\w+)(?:$|\s+)(.*)'
-
-            cmd_match = re.match(
-                command_re.format(command_prefix, event.conn.nick),
-                event.content_raw
-            )
+            cmd_match = get_cmd_regex(event).match(event.content)
 
             if cmd_match:
-                command = cmd_match.group(1).lower()
-                text = irc_clean(cmd_match.group(2).strip())
+                prefix = cmd_match.group('prefix')
+                command = cmd_match.group('command').lower()
+                text = cmd_match.group('text').strip()
+                cmd_event = partial(
+                    CommandEvent, text=text, triggered_command=command, base_event=event, cmd_prefix=prefix
+                )
                 if command in self.plugin_manager.commands:
                     command_hook = self.plugin_manager.commands[command]
-                    command_event = CommandEvent(hook=command_hook, text=text,
-                                                 triggered_command=command, base_event=event)
+                    command_event = cmd_event(hook=command_hook)
                     add_hook(command_hook, command_event)
                     matched_command = True
                 else:
@@ -305,16 +323,17 @@ class CloudBot:
                     for potential_match, plugin in self.plugin_manager.commands.items():
                         if potential_match.startswith(command):
                             potential_matches.append((potential_match, plugin))
+
                     if potential_matches:
                         matched_command = True
                         if len(potential_matches) == 1:
                             command_hook = potential_matches[0][1]
-                            command_event = CommandEvent(hook=command_hook, text=text,
-                                                         triggered_command=command, base_event=event)
+                            command_event = cmd_event(hook=command_hook)
                             add_hook(command_hook, command_event)
                         else:
-                            event.notice("Possible matches: {}".format(
-                                formatting.get_text_list(sorted([command for command, plugin in potential_matches]))))
+                            commands = sorted(command for command, plugin in potential_matches)
+                            txt_list = formatting.get_text_list(commands)
+                            event.notice("Possible matches: {}".format(txt_list))
 
         if event.type in (EventType.message, EventType.action):
             # Regex hooks

--- a/cloudbot/bot.py
+++ b/cloudbot/bot.py
@@ -319,7 +319,8 @@ class CloudBot:
             cmd_match = get_cmd_regex(event).match(event.content)
 
             if cmd_match:
-                prefix = cmd_match.group('prefix')
+                command_prefix = event.conn.config.get('command_prefix', '.')
+                prefix = cmd_match.group('prefix') or command_prefix
                 command = cmd_match.group('command').lower()
                 text = cmd_match.group('text').strip()
                 cmd_event = partial(

--- a/cloudbot/event.py
+++ b/cloudbot/event.py
@@ -398,9 +398,9 @@ class CommandEvent(Event):
     :type triggered_command: str
     """
 
-    def __init__(self, *, bot=None, hook, text, triggered_command, conn=None, base_event=None, event_type=None,
-                 content=None, content_raw=None, target=None, channel=None, nick=None, user=None, host=None, mask=None,
-                 irc_raw=None, irc_prefix=None, irc_command=None, irc_paramlist=None):
+    def __init__(self, *, bot=None, hook, text, triggered_command, cmd_prefix, conn=None, base_event=None,
+                 event_type=None, content=None, content_raw=None, target=None, channel=None, nick=None, user=None,
+                 host=None, mask=None, irc_raw=None, irc_prefix=None, irc_command=None, irc_paramlist=None):
         """
         :param text: The arguments for the command
         :param triggered_command: The command that was triggered
@@ -408,12 +408,14 @@ class CommandEvent(Event):
         :type triggered_command: str
         """
         super().__init__(bot=bot, hook=hook, conn=conn, base_event=base_event, event_type=event_type, content=content,
-                         content_raw=content_raw, target=target, channel=channel, nick=nick, user=user, host=host, mask=mask,
-                         irc_raw=irc_raw, irc_prefix=irc_prefix, irc_command=irc_command, irc_paramlist=irc_paramlist)
+                         content_raw=content_raw, target=target, channel=channel, nick=nick, user=user, host=host,
+                         mask=mask, irc_raw=irc_raw, irc_prefix=irc_prefix, irc_command=irc_command,
+                         irc_paramlist=irc_paramlist)
         self.hook = hook
         self.text = text
         self.doc = self.hook.doc
         self.triggered_command = triggered_command
+        self.triggered_prefix = cmd_prefix
 
     def notice_doc(self, target=None):
         """sends a notice containing this command's docstring to the current channel/user or a specific channel/user

--- a/cloudbot/event.py
+++ b/cloudbot/event.py
@@ -423,16 +423,16 @@ class CommandEvent(Event):
         """
         if self.triggered_command is None:
             raise ValueError("Triggered command not set on this event")
+
         if self.hook.doc is None:
-            message = "{}{} requires additional arguments.".format(self.conn.config["command_prefix"][0],
-                                                                   self.triggered_command)
+            message = "{}{} requires additional arguments.".format(self.triggered_prefix, self.triggered_command)
         else:
             if self.hook.doc.split()[0].isalpha():
                 # this is using the old format of `name <args> - doc`
-                message = "{}{}".format(self.conn.config["command_prefix"][0], self.hook.doc)
+                message = "{}{}".format(self.triggered_prefix, self.hook.doc)
             else:
                 # this is using the new format of `<args> - doc`
-                message = "{}{} {}".format(self.conn.config["command_prefix"][0], self.triggered_command, self.hook.doc)
+                message = "{}{} {}".format(self.triggered_prefix, self.triggered_command, self.hook.doc)
 
         self.notice(message, target=target)
 

--- a/plugins/core/help.py
+++ b/plugins/core/help.py
@@ -9,7 +9,7 @@ from cloudbot.util import formatting
 
 @hook.command("help", autohelp=False)
 @asyncio.coroutine
-def help_command(text, chan, conn, bot, notice, message, has_permission):
+def help_command(text, chan, conn, bot, notice, message, has_permission, triggered_prefix):
     """[command] - gives help for [command], or lists all available commands if no command is specified
     :type text: str
     :type conn: cloudbot.client.Client
@@ -29,10 +29,10 @@ def help_command(text, chan, conn, bot, notice, message, has_permission):
             if doc:
                 if doc.split()[0].isalpha():
                     # this is using the old format of `name <args> - doc`
-                    message = "{}{}".format(conn.config["command_prefix"][0], doc)
+                    message = "{}{}".format(triggered_prefix, doc)
                 else:
                     # this is using the new format of `<args> - doc`
-                    message = "{}{} {}".format(conn.config["command_prefix"][0], searching_for, doc)
+                    message = "{}{} {}".format(triggered_prefix, searching_for, doc)
                 notice(message)
             else:
                 notice("Command {} has no additional documentation.".format(searching_for))
@@ -70,7 +70,8 @@ def help_command(text, chan, conn, bot, notice, message, has_permission):
             else:
                 # This is an user in this case.
                 message(line)
-        notice("For detailed help, use {}help <command>, without the brackets.".format(conn.config["command_prefix"]))
+
+        notice("For detailed help, use {}help <command>, without the brackets.".format(triggered_prefix))
 
 
 @hook.command


### PR DESCRIPTION
When the connection is configured with multiple command prefixes, like `.` and `@`, this makes the line `For detailed help, use .@help <command>, without the brackets.` use the command prefix that triggered the `help` command rather than just showing all the command prefixes.