### PR TITLE
Refactor ping timeout logic (again)

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -11,6 +11,11 @@
                 "password": "",
                 "timeout": 300
             },
+            "ping_settings": {
+                "interval": 60,
+                "warn": 120,
+                "timeout": 300
+            }
             "nick": "MyCloudBot",
             "user": "cloudbot",
             "avoid_notices": false,

--- a/config.default.json
+++ b/config.default.json
@@ -15,7 +15,7 @@
                 "interval": 60,
                 "warn": 120,
                 "timeout": 300
-            }
+            },
             "nick": "MyCloudBot",
             "user": "cloudbot",
             "avoid_notices": false,

--- a/plugins/core/check_conn.py
+++ b/plugins/core/check_conn.py
@@ -27,9 +27,9 @@ def do_reconnect(conn):
         yield from asyncio.sleep(2)
         conn._quit = False
 
-    coro = conn.try_connect()
+    coro = conn.connect(30)
     try:
-        yield from asyncio.wait_for(coro, 30)
+        yield from coro
     except asyncio.TimeoutError:
         return "Connection timed out"
 
@@ -53,9 +53,13 @@ def reconnect(conn, text, bot):
 
 def format_conn(conn):
     lag = conn.memory["lag"]
-    ping_interval = conn.config.get("ping_timeout", 60)
+    try:
+        warning = conn.config["ping_settings"]["warn"]
+    except LookupError:
+        warning = 120
+
     if conn.connected:
-        if lag > (ping_interval / 2):
+        if lag >= warning:
             out = "$(yellow){name}$(clear) (lag: {activity} ms)"
         else:
             out = "$(green){name}$(clear) (lag: {activity} ms)"
@@ -78,27 +82,53 @@ def list_conns(bot):
 
 @hook.connect
 def on_connect(conn):
+    now = time.time()
     conn.memory["lag_sent"] = 0
-    conn.memory["ping_recv"] = time.time()
+    conn.memory["ping_recv"] = now
+    conn.memory["last_activity"] = now
     conn.memory["lag"] = 0
+    conn.memory["needs_reconnect"] = False
 
 
 @hook.command("lagcheck", autohelp=False, permissions=["botcontrol"])
-@hook.periodic(30)
-@asyncio.coroutine
-def lag_check(bot):
+@hook.periodic(5)
+def lag_check(bot, admin_log):
     now = time.time()
     for conn in bot.connections.values():
         if conn.connected:
-            timeout = conn.config.get("ping_timeout", 60)
-            lag = now - conn.memory.get("ping_recv", 0)
+            ping_conf = conn.config.get("ping_settings", {})
+            interval = ping_conf.get("interval", 60)
+            warning = ping_conf.get("warn", 120)
+            timeout = ping_conf.get("timeout", 300)
 
-            if lag > timeout:
-                yield from do_reconnect(conn)
-            else:
+            last_ping = conn.memory.get("last_ping_rpl", 0)
+            if conn.memory["lag_sent"]:
+                last_ping = conn.memory["lag_sent"]
+
+            ping_diff = now - last_ping
+            lag = conn.memory.get("lag", 0)
+            last_act = now - conn.memory.get("last_activity", 0)
+            if lag > warning or last_act > warning:
+                admin_log(
+                    "[{}] Lag detected. {:.2f}s since last ping, {:.2f}s since last activity".format(
+                        conn.name, lag, last_act
+                    )
+                )
+
+            if lag > timeout and last_act > timeout:
+                conn.memory["needs_reconnect"] = True
+            elif ping_diff >= interval:
                 conn.send("PING :LAGCHECK{}".format(now))
                 if not conn.memory["lag_sent"]:
                     conn.memory["lag_sent"] = now
+
+
+@hook.periodic(30, singlethread=True)
+@asyncio.coroutine
+def reconnect_loop(bot):
+    for conn in bot.connections.values():
+        if conn.memory.get("needs_reconnect"):
+            yield from conn.connect(60)
 
 
 @hook.irc_raw('PONG')
@@ -117,3 +147,11 @@ def on_pong(conn, irc_paramlist):
     if is_lag:
         conn.memory["lag_sent"] = 0
         conn.memory["lag"] = dif
+        conn.memory["last_ping_rpl"] = now
+
+
+@hook.irc_raw('*')
+@asyncio.coroutine
+def on_act(conn):
+    now = time.time()
+    conn.memory['last_activity'] = now


### PR DESCRIPTION
- Added ping settings to default config
- Changed ping logic to also check when the server last sent something to the bot
- Cleaned up the actual reconnect logic
- Added warning messages to lag checker

This should help with the bot disconnecting from a network after running a command like `updateusers` which does a `NAMES` on every channel the bot is in.