### PR TITLE
Improve parsing the source of fmylife.com

### DIFF
--- a/plugins/mylife.py
+++ b/plugins/mylife.py
@@ -20,13 +20,18 @@ def refresh_fml_cache(loop):
     request = yield from loop.run_in_executor(None, _func)
     soup = BeautifulSoup(request.text)
 
-    for e in soup.find_all('article', {'class': 'art-panel'}):
-        div = e.find('div', {'id': re.compile('card')})
-        if not div:
+    for e in soup.find_all('p', {'class': 'block'}):
+        # the /today bit is there to exclude fml news etc.
+        a = e.find('a', {'href': re.compile('/article/today')})
+        if not a:
             continue
 
-        fml_id = int(div['id'].split('-')[-1])
-        text = ''.join(e.find('p').find_all(text=True))
+        # the .html in the url must be removed before extracting the id
+        fml_id = int(a['href'][:-5].split('_')[-1])
+        text = a.text.strip()
+        # exclude lengthy submissions
+        if len(text) > 375:
+            continue
         fml_cache.append((fml_id, text))
 
 

--- a/plugins/mylife.py
+++ b/plugins/mylife.py
@@ -29,8 +29,9 @@ def refresh_fml_cache(loop):
         # the .html in the url must be removed before extracting the id
         fml_id = int(a['href'][:-5].split('_')[-1])
         text = a.text.strip()
-        # exclude lengthy submissions
-        if len(text) > 375:
+        
+        # exclude lengthy submissions and FML photos
+        if len(text) > 375 or text[-3:].lower() != "fml":
             continue
         fml_cache.append((fml_id, text))
 


### PR DESCRIPTION
Currently the way the source of [fmylife.com](http://www.fmylife.com/) is parsed, mostly truncated versions of the submissions on the site are outputted:

>19:29 \<user> .fml
>19:29 \<my gonzobot> (#272093) Today, according to my girlfriend's instant messenger, which she left open on my laptop, I am her secret rough shag on the side while she searches for...

This PR modifies the way submissions are parsed from the site in order to fix this issue. In addition, lengthy submissions posted on the site are now ignored so that gonzobot doesn't have to cut the ends of these submissions.