### PR TITLE
Fix urban.py after changes in the API

### DIFF
--- a/plugins/mylife.py
+++ b/plugins/mylife.py
@@ -20,13 +20,18 @@ def refresh_fml_cache(loop):
     request = yield from loop.run_in_executor(None, _func)
     soup = BeautifulSoup(request.text)
 
-    for e in soup.find_all('article', {'class': 'art-panel'}):
-        div = e.find('div', {'id': re.compile('card')})
-        if not div:
+    for e in soup.find_all('p', {'class': 'block'}):
+        # the /today bit is there to exclude fml news etc.
+        a = e.find('a', {'href': re.compile('/article/today')})
+        if not a:
             continue
 
-        fml_id = int(div['id'].split('-')[-1])
-        text = ''.join(e.find('p').find_all(text=True))
+        # the .html in the url must be removed before extracting the id
+        fml_id = int(a['href'][:-5].split('_')[-1])
+        text = a.text.strip()
+        # exclude lengthy submissions
+        if len(text) > 375:
+            continue
         fml_cache.append((fml_id, text))
 
 

--- a/plugins/mylife.py
+++ b/plugins/mylife.py
@@ -29,8 +29,9 @@ def refresh_fml_cache(loop):
         # the .html in the url must be removed before extracting the id
         fml_id = int(a['href'][:-5].split('_')[-1])
         text = a.text.strip()
-        # exclude lengthy submissions
-        if len(text) > 375:
+        
+        # exclude lengthy submissions and FML photos
+        if len(text) > 375 or text[-3:].lower() != "fml":
             continue
         fml_cache.append((fml_id, text))
 


### PR DESCRIPTION
Apparently there have been some changes in the API used by `urban.py`. Firstly, the key `result_type` has been removed. Secondly, for whatever reason words in definitions containing links have `[]`-tags surrounding them.

For example, the word "GNU/Linux" at https://www.urbandictionary.com/define.php?term=Gentoo&defid=1653311 is displayed as "[GNU/Linux]" in the [definition returned by the API](https://api.urbandictionary.com/v0/define?term=gentoo).

This PR fixes the issue of `result_type` missing and implements a workaround for the `[]`-tagging.