### PR TITLE
Revert "Bump pytest-pylint from 0.9.0 to 0.12.0"

### DIFF
--- a/travis/requirements.txt
+++ b/travis/requirements.txt
@@ -4,7 +4,7 @@ pytest-cov==2.5.1
 pytest-pep8==1.0.6
 pytest-leaks==0.2.2
 pytest-travis-fold==1.3.0
-pytest-pylint==0.12.0
+pytest-pylint==0.9.0
 flake8==3.5.0
 python-coveralls==2.9.1
 pylint==1.8.4


### PR DESCRIPTION
This reverts commit d592f9ab993b87902608b32b58c7120a87a4e30f.