### PR TITLE
Fresh jokes

### DIFF
--- a/data/book_puns.txt
+++ b/data/book_puns.txt
@@ -1,926 +1,926 @@
-Sound as a Bell: A. Clanger
-My Boring Career: A. Driller
-Dull Pain: A. King 
-The Unknown Rodent: A. Nonny Mouse
-The Frozen South: A. Winterbottom
-Drink No More!: A. A. Member 
-Ouch!: A. B. Stung
-Electrical Wiring Made Easy: A. C. Deesey 
-In Year One: A. D. Calendar 
-Vowel Promissory Notes : A. E. I. O'You
-Robotics Handbook: A. I. Expert 
-Singing Without An Orchestra: A. K. Pella 
-Morning Radio: A. M. Effem 
-Roger Wilco: A. O. Kaye 
-Bee Stings Are in the Hand of the Bee Holder: A. P. Airy 
-Let's Play Billiards: A. Q. Ball 
-The Old Codger: A. T. Yearsold 
-How To Get Attention: A. U. Overthere 
-Bird Brains: A. V. Airy 
-Who Cares?: A. Y. Nott 
-Summer in the South: A. Z. Hot-Humid 
-Rhythm & Blues for Wasps: Aaron Bee
-One Hundred Years Old: Abbie Birthday 
-Say The Magic Word: Abby Cadabra 
-My Career As A Clown: Abe Ozo 
-Drafted!: Abel Boddeed 
-I Want to Help: Abel N. Willin
-Self Denial Made Easy: Abner Gation 
-I'm not a Mutant: Abner Mallety 
-Nuclear Explosives: Adam Baum
-Ambulance Driving: Adam Muhway 
-I Love Mathematics: Adam Up
-Why I Fart: Aida Burrito
-Cry Wolf: Al Armist
-Sea Birds: Al Batross
-Cooking Spaghetti: Al Dente
-Oh What A Relief It Is: Al Kaseltzer 
-New Mexico Tour Book: Albie Kerky 
-Held Hostage by Italian Terrorists!: Aldo Anything 
-It's a Shocker: Alec Tricity
-Luxury Automobile: Alexis Carr
-Outdoor Activities: Alf Resco
-Acrophobia Explained: Alfredo Heights 
-Crocodile Dundee: Ali Gator
-Soak Your Ex-Husband: Ali Money
-Land of Plenty: Alison Ann Moore
-Is that it?: Annie Moore 
-Lewis Carroll: Alison Wonderland 
-And the Other People: Allan Sundry
-I Love You!: Alma Hart
-Funny Astronomy Texts: Alma Jest
-I Wuz Robbed!: Alma Money 
-Dirty Harry is... : Amanda B. Reckondwith
-Not a Guitar!: Amanda Lin
-What is dinner?: Amelia Eatt
-Not Very Expensive: Amir Pittance 
-My Life With Annette: Amos Kateer 
-Mountain Climbing: Andover Hand
-Maritime Disasters: Andrea Doria
-Artificial Weightlessness: Andy Gravity
-Theft and Robbery: Andy Tover
-Snorting My Way To Heaven: Angel Dust 
-The Irish Heart Surgeon: Angie O'Plasty 
-The Perils Of Drug Addiction: Anita Fixx 
-Unemployed: Anita Job
-I Like Fish: Ann Chovie
-Pain Relief: Ann L. Gesick
-Keeping Old Furniture Looking Good: Ann Teak
-Animal Illnesses: Ann Thrax
-Unwanted Babies: Anna Bortion
-Snakes of the World: Anna Conda
-Modern Tree Watches: Anna Log
-Eating Disorders: Anna Rexia 
-I Shoot Arrows: Anne Archer
-Robots: Anne Droid
-Pull Yourself Together!: Annette Curtain
-Masterpieces Of Fox TV: Annette Work 
-Home Alone III, The Sequel: Annie Buddyhome 
-Uncle Buck: Ant Lerz2
-Bit on the Leg: Anton Marnie
-May Flowers: April Showers
-Where to Find Islands: Archie Pelago
-Keep it Clean!: Armand Hammer
-Modern Music: Arun Bee
-The Bird Collection: Arnie Thologie
-Misunderstood: Art Tistic 
-It's a Fake!: Artie Fishul
-The Empty Cookie Jar: Arthur Anymore
-Inflammation, Please!: Arthur Itis 
-Vegetable Arrangements: Arty Choke
-Turkish Minerals: Asa Miner
-Light Brown Hair: Audrey Mauve Jeannie
-It Blew Off My Hat!: Augusta Wind
-How to Annoy: Aunt Agonize
-Life Before The Civil War: Aunty Bellum 
-Glitz and Bling: Austin Tay-Shuss
-What the Butler Saw: Ava Nutherluk
-The Paper Route: Avery Daye 
-Car Repairs: Axel Grease 
-How to Make Honey: B. A. Beaman
-Red Vegetables: B. Troot
-Good for a Placemat: B. A. Degree 
-Who Killed Cock Robin: B. B. Gunn 
-Prehistoric Finds: B. C. Calendar 
-Training for the Olympics: B. D. Best 
-The Disco Craze: B. G. Singers 
-Golfer's Sandwich: B. L. Tee 
-The Bedpan Patrol: B. M. Routine 
-Not a Moment to Spare: B. N. Time 
-Why Do People Avoid Me?: B. O. Problem 
-The Art of Trading: B. R. Gain
-How to Lie and Get Away With It: B. S. Artist 
-Handbook of Great Art: B. U. Teeful 
-How to Go Broke Fast: B. X. Travagant 
-Keep Out!: Barb Dwyer 
-Songs For Children: Barbara Blacksheep 
-Outdoor Cookery: Barbie Cue 
-Drink this Before the X-Ray: Barry Um
-Guide To Mixology: Bart Ender 
-The Criminals Of Watergate: Barton Mee 
-Kindergarten Kop II: Bea Hayve 
-Archery: Beau N. Arrow
-Ringing Wet: Belinda Water 
-Rich People: Belle Yenere
-Good Works: Ben Evolent
-I Love Wills: Benny Fishery
-The Pullman Sleeper: Bertha Buv 
-Lotsa Luck: Bess Twishes 
-Uninteresting Road Signs: Bill Bored
-Houses, Offices, and Apartments: Bill Ding
-Where to Put Your Money: Bill Fold
-House Construction: Bill Jerome Holme
-How to Maintain Good Credit: Bill Zarpaid
-I'm in Debt: Bill Zardeux
-Monkey Shines: Bob Boone
-Things To Do At Parties: Bob Frapples 
-Teenagers Of The '50's: Bobbie Sox 
-I Hate Fighting: Boris Hell
-The Last Roundup: Brandon Irons 
-Smart Beer Making: Bud Wiser
-Prevent Drowning: Buddy System 
-The Smorgasbord: Buffy Dinner 
-Smash His Lobster!: Buster Crabbe
-Trim Those Sideburns Too?: Buzz Cutt 
-Nitpicker's Guide to Star Trek: C. A. Flaw 
-That's a Ten-Four, Good Buddy: C. B. Radio 
-Rock Music of the 60's: C. C. Rider 
-Naval Recruitment Slogans: C. D. World 
-Look, Up In The Sky!: C. H. Etplane 
-Perfect Agreement: C. I. Tu'Ai 
-The Peeping Tom: C. K. Undress 
-Marine Mammal Communication: C. L. Barking
-The Dog Track: C. M. Run 
-XYZ: C. My Willie
-The Coast Is Clear: C. N. Eebuddy 
-Causing the Greenhouse Effect: C. O. Too 
-Lifesaving Techniques: C. P. Arr 
-Echinoderms: C. Q. Cumber and C. Lily
-The Strip Joint: C. R. Boddies 
-The Nerd: C. S. Major 
-Toodleeoo, Dear: C. U. Soon 
-Superman's Vision: C. X. Rayz 
-The End That Justifies the Means: C. Y. Eyedidit 
-Joe Wins at a Track Meet: C. Howie Runns
-French Cheeses: Cam M. Bert
-The Music Of Sammy Davis Jr.: Candy Mann 
-Feelings: Cara Lott 
-Ecclesiastical Infractions: Cardinal Sin
-How To Tune Up Your Auto: Carl Humm 
-Dinner's Ready!: Carmen Gettit 
-Meat Eaters: Carney Vore 
-Too Drunk to Walk: Carrie Mee-Ohm 
-Singing Solo: Carrie O'Kee
-Life In The Sorority House: Carrie Onn 
-Handsome, Charming, and... : Cary Smattic 
-Boy Scout's Handbook: Casey Needzit 
-We Take Credit Cards, But...: Cassius Better
-Jewish Egotists: Chaim Wonderful
-Obscure Cooking Aids: Che Fingdish 
-Equine Leg Cramps: Charlie Horse
-Sofa so Good: Chester Field
-Classic Groceries: Chopin Liszt
-The Greasy Spoon: Chris Coe 
-Perfect Cooking: Chris P. Bacon A3
-Mineralogy for Giants: Chris Tall
-What's For Dinner?: Chuck Roast 
-Prayers For Children: Cindy Skool 
-I Read You Like A Book: Claire Voyant 
-Explaining it Better: Clara Fie
-Back Row Of The Orchestra: Clara Nett 
-Shoes For Farm And Ranch: Claude Hopper 
-Bobcat under the Bleachers: Claude BottomsF
-Destructive Cats: Claude Sofa
-The Lion Attacked: Claudia Armoff
-House Plants: Clay Potts 
-Shaky Knees: Cliff Diver 
-Boring Midwestern Cities: Cole Lumbus 
-Take a Break!: Colin Sick
-Military Fast: Colonel O'Corn
-Pentagon Press Release: Colonel O'Truth and Lotta Lies
-The Sheet She Wore to the Party: Connie Stoga 
-Does Not Prove Causation: Cora Layshun
-East Coast Universities: Cora Nell
-Flogging in the Army: Corporal Punishment
-Fortune Telling: Crystal Ball 
-Paintings with Vegetables: Currier Endives
-Interior Decorating: Curt Enrod 
-Nuts about You!: Cy Cosis
-Exercise on Wheels: Cy Kling
-Wooden Percussion: Cy L'Phone 
-Solving Crimes: D. Tective
-Perry Mason's Last Case: D. A. Zoffuss 
-The Senator: D. C. Resident 
-Banned Pesticides: D. D. Tee
-I Swing for the Pitcher: D. H. Batter
-What I Dance To: D. J. Music
-Garlic Gone Bad: D. K. Stinky
-The World's Last Days: D. N. Izneer
-Didn't Make it to the Hospital: D. O. Way
-I Scream, You Scream...: D. Q. Restaurant 
-The Drawbacks of Strong Drink: D. T. Sufferer 
-I Got a New Car: D. U. Care
-How Sweet It Is: D. X. Stacy 
-I Keep Falling Down: D. Z. Person
-We're All Flakes: Dan Druff 
-Shhh!: Danielle Soloud 
-Indiana Jones' Adventures: Darrin Rescue 
-Tape Another Channel: David E. O. Recorder 
-Great Tennis Matches: Davis Skupp 
-A Boxing Cornerman's Story: Dawson DeTowel 
-Fixing Computer Programs: Dee Bugger 
-The Realm of the Dead: Dee Seized
-The Twelfth Month: Dee Sember 
-Make Up Your Mind: Dee Side 
-Racketeering: Dennis Court
-Suntanned Legs: Denise R Brown
-Baby Mess-Trappers: Di Perrs 
-Webster's Words: Dick Shunnary
-Tyrant of the Potatoes: Dick Tater
-Fistfights: Donny Brooke 
-Come on in!: Doris Open
-Life Six Feet Under: Doug Graves 
-En Garde!: Drew Blood 
-Poisonous Plants: Dudley Nightshade 
-I Like Coffee: Duncan Doughnuts
-Housework: Dustin Cook
-Highway Travel: Dusty Rhodes
-Plumb Good: Dwayne Pipe 
-Where's the Water?: Dwayne Dwight Out
-A Great Plenty: E. Nuff
-Cheer for Your Team!: E. A. Hoo
-Hard Cheese!: E. Dam 
-How to Handle Nitroglycerine: E. C. Duzzit 
-Circuit Analysis: E. E. Major 
-Amazing Alphabet!: E. F. Gee
-Old Macdonald's Farm: E. I. Eeyioh 
-Rodent in the House!: E. K. Mouse
-Ambition and Failure: E. Peter. DoubtE
-Science Fiction Stories: E. T. Fonehome 
-How to be a Con Artist: E. Z. Money 
-Christmas Dinner is Over at Last: Ed Anuff 
-Revising my Work: Eddie Torr
-And so on and so forth: Ed Nauseum
-I Lost My Balance: Eileen Dover and Phil Down
-Fat Lady In The Sideshow: Ellie Funt 
-How to Draw: Ellis Strait
-Confessions Of A Gold Digger: Emile Ticket 
-I'm Scared!: Emma Fraid 
-Columbus, Vespucci, And Me: Enzo DiUrth 
-Why Tires aren't Flat: Erin Side
-Employment Handbook: Ernie Living 
-She Saw Him: Esau Her
-I Like Liquor: Ethel Alcohol
-Turtle Racing: Eubie Quick
-Prepare To Meet Your Maker: Eva DeStruction 
-Assault with Battery: Eva Ready
-Jello Proselytizing: Evan Jellist
-Boiled Dry: Eve Aporate 
-Pull with All You've Got!: Eve Ho
-Fastest Gun In The West: Everett DeReady 
-Investigating Optometrists: F. B. Eye
-Easy Listening: F. M. Radio 
-Put Some Fizz Back In Your Life: F. R. Vessant 
-Clever Replies: F. U. Two
-100 Pounds: F. V. Load
-Animal Scents: Farrah Mones 
-Not Near: Farrah Way
-Look Younger: Fay Slift 
-Raising Flowers By Hand: Flo Wrist 
-Rangers In The Night: Forrest Fyar 
-French Overpopulation: Francis Crowded
-Hot Dog!: Frank Furter
-To be Honest: Frank Lee
-I Say So!: Frank O. Pinion
-The Great Escape: Freida Convict
-Golly Gosh!: G. Whiz
-Bringing Good Things To Life: G. E. Appliances 
-College for Soldiers: G. I. Bill 
-Lousy American Cars: G. M. Clunker
-Republican Eliminations: G. O. Pee
-On The Cover: G. Q. Model 
-Come On Mom, Pleeeeease?: G. Y. Nott 
-I Hate Monday Mornings: Gaetan Upp
-Strong Winds: Gail Force 
-Mensa Man: Gene Yuss
-Army Jokes: General Hillary Tee
-How to be a Vague Soldier: General Lee 
-Gone With The Wind: George Uh 
-Try, Try Again: Getty Trite
-I Wuz Framed!: Gil Tee 
-Soda Pop History: Ginger Aile
-Hiya Fella: Gladys Eeya 
-I Hate the Sun: Gladys Knight
-Scottish Kilt Patterns: Glen Pladd 
-We Do Theft Cases: Grabbitt & Run 
-The National Science Foundation: Grant Money 
-Genie in a Bottle: Grant Wishes
-Put'er There, Pal!: Greg Garious 
-Stomach Flu: Gretchen Barf
-Lawyers of Suffering: Grin and Barrett
-The World's Best Recipes: Gus Tatorial 
-Laid Off!: Gwen Home 
-Model Train Fanatics: H. O. Scale
-The Good Breakfast: Hammond Deggs 
-Jewish Holidays: Hannah Kuhh 
-Lazy Employees: Hans Doolittle
-The German Bank Robbery: Hans Zupp 
-Get Moving, Slowpoke!: Harriet Upp
-Rapunzel, Rapunzel!: Harris Long
-Toupee Embarrassment: Harrison Backwards
-The Beach Bully: Harry Ayp 
-At The Bottom Of The Can: Hazel Nutt 
-Gangway!: Hedda Steam 
-Cab Calloway's Garden: Heidi Ho 
-I Lived in Detroit: Helen Earth
-Where the World is Going: Helena Handbasket
-In The Trenches: Helmut Wearer 
-Greek Unbeliever!: Hera Tick
-A Bestiary of Plant Eaters: Herb Avore 
-His Girl Thursday: Herman Friday
-Hunger In America: Heywood Jafeedme 
-Funny Women: Hillary Uss
-Human Resources Manager: Hiram N. Firem 
-Stunned Over Christmas: Holly Daze
-Tinseltown Tales: Holly Wood 
-Poetry in Baseball: Homer
-Who Killed Cock Robin?: Howard I. Know
-I'm Fine: Howard Yu
-Chinese Apathy: Hu Cares
-Mystery in the Barnyard: Hu Flung Dung
-I Laugh at the Gods!: Hugh Briss
-Big Fart!: Hugh Jass
-Lots of Excitement: Hugh N. Cry
-Greeting Sheep Strangers: Hugh R. Ewe
-Parachuting: Hugo First
-Midnight Patrol: Hugo Sair 
-No Camels Here!: Humphrey Zoo
-Computer Programming Made Easy: I. B. Emm 
-Hazardous Driving: I. C. Rhodes 
-I Lost at Hide-And-Seek: I. C. U. Hiding 
-Well, I Never!: I. D. Claire 
-I'm Not Getting Older, I'm Getting Better!: I. H. Tenyears 
-How To Talk Good: I. I. Stutter 
-Minor Infractions: I. J. Walk 
-The Myth of the Mafia: I. L. Killya 
-The Excitement of Trees: I. M. Board
-Loan Sharking Made Easy: I. O. Yew 
-An Anthology of Children's Humor: I. P. Dailey 
-Rusty Bedsprings: I. P. Nightly
-Mental Giants: I. Q. Test 
-Hand It All Over!: I. R. Ess 
-Desert Crossing: I. Rhoda Camel
-Fore!: I. T. Off
-Contraception: I. U. Dee 
-Expensive Universities: I. V. League 
-High Stakes Poker Tactics: I. W. Betts JG5
-Teach Me!: I. Wanda Know
-Bugs Beware!: I. X. Terminate
-Balancing Act: I. Y. Yerr 
-The Garden State: Ida Hoe 
-Let's Do it Now!: Igor Beaver
-Take This Job And Shove It: Ike Witt 
-I'm Someone Else: Ima Nonymous
-The Phillipine Post Office: Imelda Letter 
-Fred Can Philosophize!: Immanuel Kant
-No More Circuit Breakers!: Ira Fuse
-Cloning: Irma Dubble II
-What I Took: Irv Erginity 
-In the Arctic Ocean: Isa Berg
-I Hit the Wall: Isadore There
-Why We Fall in Winter: Isis Slippery
-I Didn't Do It!: Ivan Alibi
-Mosquito Bites: Ivan Itch
-Russian Tennis Shoes: Ivan Odor
-My Seventh Husband: Ivana Newhouse 
-Amnesia on Demand: Ivor Gett
-Cheating on His Wife: Izzy Backyet 
-Can't Fence Me In!: J. L. Breaker 
-A Critique of Ian Fleming: J. M. Spond 
-Candle-Vaulting: Jack B. Nimble
-Fingerplay: Jacob Sladder 
-Split Personalities: Jacqueline Hyde 
-Don't Do Anything Rash: Jacques Itch 
-Athletic Supporter: Jacques Strap
-The Dead Of Winter: Jan Yuary 
-How to Clean Up Birdwatching: Janet Oriole 
-Renowned Chefs: Janice Cooks
-Not Bogged Down In Reality: Jason Rainbows 
-What Makes Airplanes Go: Jeff Fuel 
-Hockey for Grandparents: Jerry Hattrick
-I Can Fix It: Jerry Rigg 
-The Source of Electricity: Jenny Rator 
-I Beat Bobby Fischer: Jess Player 
-Birdwatching for Beginners: Jesse the ParrotE
-From the Great White North: Jessica Nadian 
-Party On, Dude: Jill Out 
-The Scent Of A Man: Jim Nasium 
-Flips and Tumbles: Jim Nastics
-The Monkey Cage: Jim Panzee 
-How to Break In: Jimmy De Lock 
-Those Funny Dogs: Joe Kur
-How To Make Cornmeal Pancakes: Johnny Cake 
-Star Spangled Barrio: Jose Canusee 
-The Hitchhiker: Juan Nalift 
-Two Thousand Pounds!: Juan Ton
-Personal Tutoring: Juan Touwan 
-The Friendly Bartender: Juana Beer
-The Chuck Berry Story: Judy Frudy 
-Life is a Trial: Judd Gement 
-I Work with Diamonds: Jules Sparkle
-Options Trading: June Gold 
-Look Ma, No Thumbs!: Justice Fingers 
-I Need Insurance: Justin Case
-Almost Missed the Bus: Justin Time
-Poultry Farmers: Justus Chickens 
-When Baseball Heros Strike Out: K. C. Atbatt
-Nothing to Chirp About: K. D. Didd 
-How to Reply without Committing Yourself: K. G. Answer
-Bigots of America: K. K. Kaye
-How to Go Dutch on a Plane: K. L. Emm
-Hot Stuff!: K. N. Pepper
-I Coulda Been A Contender: K. O. Boxer 
-A Thousand Potatoes Yet To Go: K. P. Dooty 
-Working in a Nursing Home: K. R. Giver
-The Day All Heck Broke Loose: K. T. Bardedoor 
-Slip-Slidin' Away: K. Y. Jellee 
-The LA Lakers' Breakfast: Kareem O'Wheat 
-Chirpin' and Jumpin': Katie Didd 
-After The Corned Beef And Cabbage: Kay O'Pectate 
-Measles Collision!: Kay Rash
-Nuclear Power Bafflement: Ken Fusion 
-Ex-Presidential Retreat: Kenny Bunkport 
-A Stuntman To The End: Kenny Doitt 
-Woulda Been A Great Shortstop: Kent Hitt 
-Breaking the Law: Kermit A. Krime
-Don't Let Me Stop You: Kerry Onn 
-Yoko's Robe: Kim Ono 
-A Whole Lot of Cats: Kitt N. Caboodle
-The Economy is Recovering!: Knott Quite
-Pressure Relief: Korsetsov
-No: Kurt Reply 
-Southern California Pachyderms: L. A. Funt
-The Terminator: L. B. Back
-Tennis Consequences: L. Bow-Payne
-History of Borden's Dairy Products: L. C. DeCow 
-Illicit Sea Bird Activities: L. E. Gull
-Who Ate All the Cookies?: L. F. Eyeno
-If I Had The Chance: L. I. Wood 
-The Role of the Hit Man: L. M. Innate
-Whose Face Can Launch 1000 Ships?: L. N. OTroy 
-New In Town?: L. O. Saylor 
-What Music Used to Be On: L. P. Record
-The Last Frontier: L. S. Kah JG6
-I Don't Believe This!: L. U. Say
-Anything on a Dare: L. Y. Nott 
-Here's Pus In Your Eye: Lance Boyle 
-Honest Citizen: Laura Byder 
-Crackdown: Lauren Order 
-Nobel Prize Cannibals: Laurie Ate 
-Music of the Sea: Lawrence Whelk
-Tight Situation: Leah Tard 
-More Mindless Violence: Lee Fullweapon 
-You Drip!: Lee K. Fawcette
-The Palace Roof has a Hole: Lee King
-Nordic Groundskeepers: Leif Raker 
-The Shrinking Society: Les Ismoor 
-Bad Investment: Les Riches
-James Fenimore Cooper: Lester Moe Hickens
-Jewish Mysticism: Lev Itation
-Joys of Cowardice: Lily Livard 
-Volunteer's Guidebook: Linda Hand 
-Meals On Safari: Lionel Eecha 
-Hertz, Don't It?: Lisa Carr 
-Italian Delicacies: Liz Onya 
-I Love Fractions: Lois C. Denominator
-How to Cut Grass: Lon Moore
-Scots in the Desert: Lorna Dune
-Punk Rock Rulez!: Lotta Noyze 
-Good Housekeeping: Lotta Dust
-Mardi Gras Time: Lou Isiana 
-Tear Up Those Betting Slips: Lou Zerr 
-The Ham Radio Primer: Loudon Clear 
-He's Contagious!: Lucas Measles
-Fallen Underwear: Lucy Lastic 
-Tabletop Occultism: Luigi Board
-Danger!: Luke Out
-Not So Hot: Luke Warm 
-Irish Flooring: Lynn O'Leum
-Now I'm in Business!: M. B. Yay
-How to Address an Audience: M. C. Speaker
-What's Up, Doc?: M. D. Degree 
-Great Television Shows: M. E. Awards 
-British Sports Cars: M. G. Auto
-On Her Majesty's Secret Service: M. I. Five
-Perverted Mushrooms: M. Morel
-How to Become Famous: M. N. Ent 
-The Musical World of Walt Disney: M. O. Yewessee 
-Enforcing Discipline in the Army: M. P. Copps
-Kingdom of the Flames: M. Pyre
-They're Not Cows: M. R. Horses 
-How to Slow Down your Computer: M. S. Windoze
-Why Cars Stop: M. T. Tank
-Do as I Do, Not as I Say: M. U. Late 
-Makeup for Thin People: Mabel Leen
-You're So Sweet: Mable Syrup 
-Italian Cooking: Mac Aroni
-Round the World: Madge Ellen
-It's All In Your Head: Madge Ination 
-Shamans and Witch Doctors: Madison Menn
-I Was a Cloakroom Attendant: Mahatma Coate
-Military Defeats: Major Disaster and General Mayhem
-I'm not a happy camper!: Malcolm Tent
-I Like Weeding Gardens: Manuel Labour
-Personal Best: Marco DeStinction 
-The Truancy Problem: Marcus Absent 
-Kangaroo Illnesses: Marcus Wallaby, M.D.
-Don’t Cry for Me: Marge and Tina
-Ship Mysteries: Marie Celeste
-Where to park your boat: Marina Dock
-Repent At Leisure: Marion Hayste 
-Scuffed Floors: Mark Tupp 
-Care For A Chop?: Marsha Larts 
-Military Rule: Marshall Law
-Quips For The Young At Heart: Marty Pants 
-Happy New Year!: Mary Christmas
-Nice Hotels: Mary Ott
-I Love Bullfighting: Matt Adore 
-Fire Me Up!: Matt Chez
-Home Decorating: Matt Emulsion
-Scandinavian Photography: Matt Finnish 
-Very Precise: Matt Iculous 
-Weepy Movie: Maud Lynn Story
-The TV News Anchorman: Maury Ports 
-More for Your Money: Max Amize
-Pilgrim Settlers: May Flower 
-Continental Recipes :May O'Nez
-Riel Ambush!: May T. Surprise
-Computer Memories: Meg Abight
-It Won't Work!: Mel Function 
-Irish Soap Operas: Mel O'Drama 
-Caught in a Cyclone: Mel Strom
-Specialty Winemaker: Merle O. Vintner
-Overcoming Nervousness On Radio: Mike Fright 
-Geez, It's Hot!: Mike Hammeldyed
-Clothes for Germ Kings: Mike Robes
-Daddy are We There Yet?: Miles Away
-When's The Revolution?: Millie Tant 
-Decorating your Mousehole: Minnie Blinds
-Many Are Cold, But Few Are Frozen: Minnie Sota 
-Long Walk: Miss D. Bus
-Errors and Accidents: Miss Takes and Miss Haps
-Car Capital Of The World: Mitch Egan 
-Ohh, the Pain, the Pain!: Moe N. Groan
-Cut the Grass!: Moe Lawn
-The Porn Queen: Mona Lott 
-Gambling: Monty Carlos
-Mexican Revenge: Monty Zuma
-No More Rifles!: Morgan Control 
-I Love Crowds: Morris Merrier
-Cut the Grass!: Moses Lawn
-Wouldn't You Know It: Murphy Slaw 
-French Cars: Myra Neault k7
-I Disagree With That!: N. A. Sayer
-History of Professional Basketball: N. B. Yay 
-College Basketball in the South: N. C. State 
-The Hoosier State: N. D. Anna 
-I'm Not Choosy: N. E. Buddy 
-History of Professional Football: N. F. Ell 
-Medical Procedures: N. G. OGram 
-Unsolved Mysteries: N. Igma
-Pain Killers: N. L. Gesic 
-Have Fun at the Hospital!: N. M. Uhh 
-Book Puns are a Nuisance: N. O. Ying 
-You're Welcome: N. Q. Verymuch
-Everyone Needs a Gun!: N. R. Ray
-Hypnotism: N. Tranced
-Slam Dunk Champions: N. U. Face 
-The Grass Is Always Greener: N. V. Uss 
-Noise is Forbidden!: Nada Loud
-East Coast Resorts: Nan Tuckett 
-American College Athletics: Nancy Dubblelay 
-The Spiritual Life: Ned Itation
-Ready for Knighthood: Neil Downe 
-Smoker's Cough: Nick O'Teen 
-It's a Holdup!: Nick R. Elastic
-Dull Razor: Nick Shaving 
-Political Correctness: Noah Fence
-My Lost Causes: Noah Veil
-The Great Flood: Noah Zark 
-I'm an Atheist: Noel Noheaven
-Neither a Borrower: Nora Lender Bee
-Overweight Vegetables: O. Beets
-I'm Always Hungry: O. B. City 
-Bad Trips: O. D. Ondope
-The Errant Sledgehammer: O. G. Datturts 
-The White Flag: O. I. Givupp 
-Better Than Concentrate: O. J. Squeezer 
-The Good Employee: O. K. Boss 
-I Dropped the Hammer: O. L. Myfoot
-First Aid for Kids: O. O. Owie 
-Health Food Cereal: O. T. Brann
-Slang from the Roaring Twenties: O. U. Kidd 
-You're Being Audited!: O. Y. Mee 
-Swedish Perfumeries: Ole Factory
-The Peace Mission: Olive Branch 
-Without Warning: Oliver Sudden
-Handel's Messiah: Ollie Luyah 
-Surprised!: Omar Gosh
-The Empath: Ophelia Sadness 
-Season Tickets: Oprah Maven
-Singin' and Shakin': Oprah Tic Tenor
-Life Before Cars: Orson Buggy 
-Pain in My Body: Otis Leghurts
-I Must Fix the Car!: Otto Doit
-The Industrial Revolution: Otto Mattick
-He Disappeared!: Otto Sight
-Money Management: Owen Cash
-And Now the Following Announcements: P. A. System
-Favourite Sandwiches: P. B. Enjam 
-Cheaper than IBM: P. C. Clone
-Do It Now!: P. D. Cue 
-Get In Shape!: P. E. Class 
-No Children Please!: P. G. Thirteen
-We Solve Mysteries: P. I. Detective
-Favorite Sleepwear: P. J. Bottoms 
-Light My Fire!: P. K. Power (PK=Pyrokinesis)
-First Step to French Fries: P. L. Potatoes
-How to Take Afternoon Naps: P. M. Snooze
-Tickling the Ivories: P. N. Noe 
-The Urinalysis: P. P. Inacupp 
-Eccentrics I Have Known: P. Q. Lyirr 
-How to Deal with the Media: P. R. Department 
-Early History of the Beatles: P. S. Iluvya 
-Ships of the Navy: P. T. Bote 
-Encounter with a Skunk: P. U. Reek 
-What Makes Army People Sick: P. X. Food
-Skunks in the Shrubbery: P. Yew
-How to Read a Book: Paige Turner
-The Hidden Surprise: Pam Perz 
-Preaching to Hell's Angels: Pastor Redlight
-What's Your Invention?: Pat Tent 
-Green Lawn Chairs: Patty O'Furniture 
-Grave Mistakes: Paul Bearer
-Foot Problems of Big Lumberjacks: Paul Bunion
-Tug of War: Paul Hard
-Maritime Rules: Paula See
-The Lady Pirate: Peg Legg 
-Save Your Money: Peggy Bank
-The Miracle Drug: Penny Cillin 
-Girl On a Budget: Penny Pincher
-Herbally Yours: Penny Royal
-Mexican/Italian Food: Pepe Roney 
-Oppression of the Masses: Percy Kyution 
-The Candy Store: Pepper Mintz 
-Stop Harassing Me!: Percy Kueshun 
-Irish Dentistry: Perry O'Dontal 
-Events In The Soviet Union: Perry Stroika 
-The Bog: Pete Maas 
-In Farmer MacGregor's Garden: Peter Abbott 
-Markings in the Sand: Peter Dragon
-Slowly Fades: Peter Out A8
-Home of the Liberty Bell: Phil A. Delphia
-The History Of Exxon: Phil Errup 
-All About Orchestras: Phil Harmonic
-Exotic Irish Plants: Phil O'Dendron
-The Polarization Process: Phil Terrout 
-Hollywood Gossip: Phyllis Zinn 
-Artificial Clothing: Polly Ester
-Laughing In The White House: Polly Tickle
-How to Cook a Steak: Porter House
-Neat Shirts: Preston Ironed
-Keep 'Em That Way: Private Parts
-Find Another Lonely Heart: Q. Pid 
-Why Software is Buggy: Q. A. Tester 
-Proof Positive!: Q. E. Dee 
-Carnival Prizes: Q. P. Doll
-Fashion Models: Q. T. Pye 
-The Very Model of a Modern Major General: Quinn Tessence 
-Third of Five: Quinn Tuplet
-Violate Me and Your Program Will Crash!: R. A.Bounds
-Encyclopedia of Poisons: R. C. Nick 
-The Punny Book Title Collection 8-: R. D. Harhar
-See You In Phoenix!: R. E. Zona 
-I Shot an Arrow In the Air: R. G. Rhee 
-Sorry, You're Not My Type: R. H. Factor
-Covered Walkways: R. Kade
-Bring to the Grocer's: R. List
-It's All in the Wrist: R. M. Wrestle
-I Killed Cock Robin!: R. S. T'Me 
-Where there are Hangings Every Day: R. T. Museum
-Irish First Aid: R. U. O'Kaye
-Where to Get a Road Hog: R. V. Dealer
-Junkyards of the World: R. X. Taken
-Bigotry: Rachel Intolerance
-How I Won The Marathon: Randy Hoelway 
-Indian, Italian and Spanish Cuisine: Ravi Oley 
-Lawn Care: Ray King 
-Lewd Novels: Ray See
-How to Overcome Stress: Ray Lachs
-Chinese Stairs: Ray Ling
-Some Like It Hot: Red Pepper
-Formal List: Reggie Stirr 
-The Fortuneteller: Reid Palms 
-The Auto Salvage Business: Rex Toad 
-Well-Spoken Predictions: Rhett Oracle
-Get to the Point!: Rhonda Bout
-I'm Exhausted!: Rhonda Marathon
-I Was A Son Of A Buccaneer: Rich Kidd 
-Deflections: Rick O'Shea v:
-Weekend In Hong Kong: Rick Shaw 
-Long Way Down: Rip Cord Broke
-How to Succeed in School: Rita Book
-Armed Heists: Robin Banks
-How to Tour the Prison: Robin Steele
-As Solid as...: Rocco Gibraltar
-Gone Fishing: Rod Annette
-Fish Story: Rod Enreel 
-Okee Dokee: Roger Wilco 
-Meeting Places: Ron DeVoo
-Go Away!: Ron Onhome 
-Gardening With The Ex-President: Rose Bush 
-Cosmetology: Rosie Cheeks 
-What Geologists Study: Roxanne Minerals
-Wish I'd Never Been Born: Rudy Daye 
-The Housing Problem: Rufus Quick
-Wind In The Maple Trees: Russell Ingleaves 
-Small Vegetables: Russell Sprout 
-The Squeaking Gate: Rusty Hinges 
-Sandwich Making: Ryan Mayo 
-Late Nights: S. A. Due
-Where She Sells Sea Shells: S. C. Shore
-Stories in the Future: S. F. Writer
-Will You Marry Me?: S. I. Will
-Whip Me into Shape: S. M. Kinky
-We all Need This!: S. N. Shall
-Compendium of Useless Tidbits: S. O. Terrick 
-Spies Like Us: S. P. O'Nage 
-The Fall of a Watermelon: S. Platt
-You Tell Me the Answer!: S. Q. Question
-Ginger vs. Mary Ann: You Decide!: S. S. Minnow 
-Your Guess is as Good as Mine: S. T. Mate
-Living on the Land: S. Tate
-Great New York City Hotels: S. X. House 
-Ready...Set...: Sadie Word 
-Wake Up!: Sal Ammoniac
-Get Out There!: Sally Forth
-Latin Dances for Sheep: Sam Baa
-Still Looking For My Heart: Sam Francisco 
-Imitating Mozart: Sam Phony
-I Can't See The Difference: Sam Ting 
-Songs from 'South Pacific': Sam and Janet Evening
-Dan Quayle's Englush Skils: Sammy Literate
-Summer Vacation: Sandy and Shelley Beach
-Southern California Waffles: Sandy Eggo 
-Brane Surjery Maid Simpel: Sarah Bellum 
-All Alone: Saul E. Terry
-Peeping Tom: Sawyer Scanties 
-How To Beat A Murder Rap: Scott Free 
-Holmes Does It Again: Scott Linyard 
-Fancy Light Fixtures: Sean D'Olier
-Tailoring: Serge Soote 
-Guarding the Door: Sergeant Atarms
-Joys of Septic Tanks: Seth Poole JG9
-Full Moon: Seymour Buns
-The Optician's Guide: Seymour Clearly 
-Under the Bleachers: Seymour Butts
-Let's see That Again!: Schlomo Replay
-Rules For Living: Sharon Sharalike 
-Get Moving!: Sheik Aleg
-You're Kidding!: Shirley U. Jest
-...And Shut Up!: Sid Downe 
-Parting Shots: Sid Semper Tyrannis
-Circle Perimiter: Sir Cumference
-The Effects of Alcohol: Sir Osis of Liver
-Cough Medicine: Sir Upp
-Children's Songbook: Skip Tumalu 
-Defunct Nations: Sophie Etunion 
-Too Rough: Soren Redd 
-The Senior Prom: Spike Drink 
-Make your Marriage Work: Stan Byerman
-Life As A Comic: Stan Dupp 
-West Coast Universities: Stan Ford 
-Making Explosives: Stan Wellback
-NHL Hockey: Stanley Kupp 
-The Telltale Heart: Stefi Scope 
-Working on the Docks: Steve Door
-Manana: Stew Layt 
-Things to Cook Meat In: Stu Potts
-The French Chef: Sue Flay 
-The Big Wave: Sue Nami
-April Fool!: Sue Prize
-Waste Water: Sue Ridgepipe
-Some Like it Sweet: Sugar Kane
-Foot Coverings: Susan Socks 
-It's Magic!: Sven Gali
-Sectarian Conflicts: Sybil War
-Why Must I Teach this Class?: T. A. Blues
-That Nagging Cough: T. B. Carrier 
-Good Steak!: T. Bone
-Not Saved By The Bell!: T. K. Ohh 
-It Aids Recovery: T. L. See 
-Needed to Make the Hot Drinks: T. Leaf 
-Explosive Beverages: T. N. Tee
-Dwelling Places of Some Native Americans: T. P. Tent
-Too Bad For You!: T. S. Sucker 
-Golfer's Caffeine Source: T. T. Hott 
-Quick and Hot: T. V. Dinner 
-Revealing Secrets: T. Zing
-Little Bitty Froggies: Tad Pole 
-Preparing Leather: Tanya Hyde 
-Coin Tossing: Taylor Hedd 
-Bad Cow Jokes: Terry Bull
-Talkative Japanese: Terry Yaki
-You Wash, I'll Dry: Terry Cloth 
-Trial Law: Tess Temoni 
-Sandpapers of the West: Tex Ture
-Who is She?: Thad Gurl 
-Theft Among Arthropods: The Lieutenants
-What Mephistopheles Did: Thelma Soul
-Musical Gunfighters: The Okay Chorale
-The World's Deadliest Joke: Theophilus Punoval 
-It's Springtime!: Theresa Green 
-Whatchamacallit!: Thingum Bob
-Falling Trees: Tim Burr
-My Life on Skid Row: Titus A. Drum 
-Off To Market: Tobias A. Pigg
-Keep them in Suspense: Toby Continued
-Battle Axes: Tom A. Hawk
-Wind Instruments: Tom Bone and O. Bowe
-Banquet at McDonalds: Tommy Ayk 
-Chicago Gangs Of The '30's: Tommy Gunn 
-Turkish Cattle: Tristan Bull
-Silly Rabbit: Trixie R. Forkids
-Ah, Thor!: Ty Till
-Do It Yourself: Tyrone Shoelaces 
-Great Jazz Pianists: U. B. Blake
-Mortal Enemies: U. I. Cantstand 
-London Bridge is Falling Down...: U. K. Tourist
-I Win!: U. Lose
-Talk Is Cheap: U. N. Envoy 
-Income Tax Time: U. O. Money
-Believe it or Not: U. R. Kidding 
-What's Green, Yet Does Not Grow?: U. S. Dollar
-Good for Nothing: U. Sless 
-The Best of Elmer Fudd: U. U. Wabbit
-Red in the Face: U. V. Index
-Jokes for All Occasions: U. Y. Sky 
-War Injuries I Have Seen: V. A. Hospital 
-Embarrassing Infectious Diseases: V. D. Clinic 
-Hitler's Beaten: V. E. Daye 
-MacArthur's Triumph: V. J. Daye 
-Dinner that Mooves You: V. L. Scallopini
-Compact Cars of the World: V. W. Bugg 
-You're a Bundle of Laughs: Vera Funny
-Avoid that Pedestrian!: Vera Way 
-Winning the Race: Vic Tree
-String Instruments: Viola Player
-New Computer Games: Virgil Reality 
-Blowout!: Vlad Tire 
-Web Browsing Made Easy: W. W. Dotcom
-Positive Reinforcement: Wade Ago 
-Carpet Fitting: Walter Wall
-Judging Fast Food: Warren Berger
-Leo Tolstoy: Warren Peace
-Woman in Danger!: Warner Quick
-Downpour!: Wayne Dwops
-Life in Chicago: Wendy City
-That was Quick!: Wendy Dothat 
-Exploring The Dutch Frontier: Will Der Ness 
-Just Say No: Will Power 
-Promises for Peace: Will Shake and Mae Kupp 
-Fifty Yards to the Outhouse: Willy Makit and Betty Woant
-Social Insecurity: Wilma Moneylast 
-Bad Gardeners: Wilt Plant
-Mobile Homes: Winnie Bago
-How to succeed at Craps: Winona Seven
-If I Invited Him...: Woody Kum
-Gunslingers with Gas: Wyatt Urp
-Engineering Instructor: Wyatt Works 
-Be Your Best!: X. L. Lent 
-Rash Decisions I Have Made: X. M.
-Hot Under the Collar: X. O. Thermic
-Hurry it Up!: X. P. Dite
-The Healthy Way to Lose Weight: X. R. Size 
-Why Our Dumps are Filling Up: X. S. Waste
-The Greatest Pleasure: X. T. See 
-Naughty Movies: X. X. Ecks
-Secrets of Dermatology: X. Z. Mahh 
-Stop Arguing: Xavier Breath
-That Woman Gives Me Deja-Vu: Xena Before 
-It's Unfair!: Y. Me
-The Wit and Wisdom of Chico Marx: Y. A. Duck 
-Lose Weight Now: Y. B. Phatt
-Make the Ceiling Higher!: Y. C. Stars
-Beans for Breakfast: Y. I. Toot
-I Didn't Do It!: Y. M. Eyehere
-Trail Guide to Yellowstone Park: Y. O. Ming 
-Get Up, Lazybones: Y. R. Yewsleeping 
-The Sayings of Homer Simpson: Y. U. Liddle 
-I Hurt Myself!: Yin Pain
-Playing with the Christmas Fire: Yule B. Sari
-Christmas for Baldies: Yule Brynner
-The Letter P: Uri Nation
-My Life in the Gutter: Yves Trough
-More Beard than Music: Z. Z. Topp
-It was Him!: Zoe Didit 
+"Sound as a Bell" by A. Clanger
+"My Boring Career" by A. Driller
+"Dull Pain" by A. King
+"The Unknown Rodent" by A. Nonny Mouse
+"The Frozen South" by A. Winterbottom
+"Drink No More!" by A. A. Member
+"Ouch!" by A. B. Stung
+"Electrical Wiring Made Easy" by A. C. Deesey
+"In Year One" by A. D. Calendar
+"Vowel Promissory Notes" by A. E. I. O'You
+"Robotics Handbook" by A. I. Expert
+"Singing Without An Orchestra" by A. K. Pella
+"Morning Radio" by A. M. Effem
+"Roger Wilco" by A. O. Kaye
+"Bee Stings Are in the Hand of the Bee Holder" by A. P. Airy
+"Let's Play Billiards" by A. Q. Ball
+"The Old Codger" by A. T. Yearsold
+"How To Get Attention" by A. U. Overthere
+"Bird Brains" by A. V. Airy
+"Who Cares?" by A. Y. Nott
+"Summer in the South" by A. Z. Hot-Humid
+"Rhythm & Blues for Wasps" by Aaron Bee
+"One Hundred Years Old" by Abbie Birthday
+"Say The Magic Word" by Abby Cadabra
+"My Career As A Clown" by Abe Ozo
+"Drafted!" by Abel Boddeed
+"I Want to Help" by Abel N. Willin
+"Self Denial Made Easy" by Abner Gation
+"I'm not a Mutant" by Abner Mallety
+"Nuclear Explosives" by Adam Baum
+"Ambulance Driving" by Adam Muhway
+"I Love Mathematics" by Adam Up
+"Why I Fart" by Aida Burrito
+"Cry Wolf" by Al Armist
+"Sea Birds" by Al Batross
+"Cooking Spaghetti" by Al Dente
+"Oh What A Relief It Is" by Al Kaseltzer
+"New Mexico Tour Book" by Albie Kerky
+"Held Hostage by Italian Terrorists!" by Aldo Anything
+"It's a Shocker" by Alec Tricity
+"Luxury Automobile" by Alexis Carr
+"Outdoor Activities" by Alf Resco
+"Acrophobia Explained" by Alfredo Heights
+"Crocodile Dundee" by Ali Gator
+"Soak Your Ex-Husband" by Ali Money
+"Land of Plenty" by Alison Ann Moore
+"Is that it?" by Annie Moore
+"Lewis Carroll" by Alison Wonderland
+"And the Other People" by Allan Sundry
+"I Love You!" by Alma Hart
+"Funny Astronomy Texts" by Alma Jest
+"I Wuz Robbed!" by Alma Money
+"Dirty Harry is..." by Amanda B. Reckondwith
+"Not a Guitar!" by Amanda Lin
+"What is dinner?" by Amelia Eatt
+"Not Very Expensive" by Amir Pittance
+"My Life With Annette" by Amos Kateer
+"Mountain Climbing" by Andover Hand
+"Maritime Disasters" by Andrea Doria
+"Artificial Weightlessness" by Andy Gravity
+"Theft and Robbery" by Andy Tover
+"Snorting My Way To Heaven" by Angel Dust
+"The Irish Heart Surgeon" by Angie O'Plasty
+"The Perils Of Drug Addiction" by Anita Fixx
+"Unemployed" by Anita Job
+"I Like Fish" by Ann Chovie
+"Pain Relief" by Ann L. Gesick
+"Keeping Old Furniture Looking Good" by Ann Teak
+"Animal Illnesses" by Ann Thrax
+"Unwanted Babies" by Anna Bortion
+"Snakes of the World" by Anna Conda
+"Modern Tree Watches" by Anna Log
+"Eating Disorders" by Anna Rexia
+"I Shoot Arrows" by Anne Archer
+"Robots" by Anne Droid
+"Pull Yourself Together!" by Annette Curtain
+"Masterpieces Of Fox TV" by Annette Work
+"Home Alone III, The Sequel" by Annie Buddyhome
+"Uncle Buck" by Ant Lerz2
+"Bit on the Leg" by Anton Marnie
+"May Flowers" by April Showers
+"Where to Find Islands" by Archie Pelago
+"Keep it Clean!" by Armand Hammer
+"Modern Music" by Arun Bee
+"The Bird Collection" by Arnie Thologie
+"Misunderstood" by Art Tistic
+"It's a Fake!" by Artie Fishul
+"The Empty Cookie Jar" by Arthur Anymore
+"Inflammation, Please!" by Arthur Itis
+"Vegetable Arrangements" by Arty Choke
+"Turkish Minerals" by Asa Miner
+"Light Brown Hair" by Audrey Mauve Jeannie
+"It Blew Off My Hat!" by Augusta Wind
+"How to Annoy" by Aunt Agonize
+"Life Before The Civil War" by Aunty Bellum
+"Glitz and Bling" by Austin Tay-Shuss
+"What the Butler Saw" by Ava Nutherluk
+"The Paper Route" by Avery Daye
+"Car Repairs" by Axel Grease
+"How to Make Honey" by B. A. Beaman
+"Red Vegetables" by B. Troot
+"Good for a Placemat" by B. A. Degree
+"Who Killed Cock Robin" by B. B. Gunn
+"Prehistoric Finds" by B. C. Calendar
+"Training for the Olympics" by B. D. Best
+"The Disco Craze" by B. G. Singers
+"Golfer's Sandwich" by B. L. Tee
+"The Bedpan Patrol" by B. M. Routine
+"Not a Moment to Spare" by B. N. Time
+"Why Do People Avoid Me?" by B. O. Problem
+"The Art of Trading" by B. R. Gain
+"How to Lie and Get Away With It" by B. S. Artist
+"Handbook of Great Art" by B. U. Teeful
+"How to Go Broke Fast" by B. X. Travagant
+"Keep Out!" by Barb Dwyer
+"Songs For Children" by Barbara Blacksheep
+"Outdoor Cookery" by Barbie Cue
+"Drink this Before the X-Ray" by Barry Um
+"Guide To Mixology" by Bart Ender
+"The Criminals Of Watergate" by Barton Mee
+"Kindergarten Kop II" by Bea Hayve
+"Archery" by Beau N. Arrow
+"Ringing Wet" by Belinda Water
+"Rich People" by Belle Yenere
+"Good Works" by Ben Evolent
+"I Love Wills" by Benny Fishery
+"The Pullman Sleeper" by Bertha Buv
+"Lotsa Luck" by Bess Twishes
+"Uninteresting Road Signs" by Bill Bored
+"Houses, Offices, and Apartments" by Bill Ding
+"Where to Put Your Money" by Bill Fold
+"House Construction" by Bill Jerome Holme
+"How to Maintain Good Credit" by Bill Zarpaid
+"I'm in Debt" by Bill Zardeux
+"Monkey Shines" by Bob Boone
+"Things To Do At Parties" by Bob Frapples
+"Teenagers Of The '50's" by Bobbie Sox
+"I Hate Fighting" by Boris Hell
+"The Last Roundup" by Brandon Irons
+"Smart Beer Making" by Bud Wiser
+"Prevent Drowning" by Buddy System
+"The Smorgasbord" by Buffy Dinner
+"Smash His Lobster!" by Buster Crabbe
+"Trim Those Sideburns Too?" by Buzz Cutt
+"Nitpicker's Guide to Star Trek" by C. A. Flaw
+"That's a Ten-Four, Good Buddy" by C. B. Radio
+"Rock Music of the 60's" by C. C. Rider
+"Naval Recruitment Slogans" by C. D. World
+"Look, Up In The Sky!" by C. H. Etplane
+"Perfect Agreement" by C. I. Tu'Ai
+"The Peeping Tom" by C. K. Undress
+"Marine Mammal Communication" by C. L. Barking
+"The Dog Track" by C. M. Run
+"XYZ" by C. My Willie
+"The Coast Is Clear" by C. N. Eebuddy
+"Causing the Greenhouse Effect" by C. O. Too
+"Lifesaving Techniques" by C. P. Arr
+"Echinoderms" by C. Q. Cumber and C. Lily
+"The Strip Joint" by C. R. Boddies
+"The Nerd" by C. S. Major
+"Toodleeoo, Dear" by C. U. Soon
+"Superman's Vision" by C. X. Rayz
+"The End That Justifies the Means" by C. Y. Eyedidit
+"Joe Wins at a Track Meet" by C. Howie Runns
+"French Cheeses" by Cam M. Bert
+"The Music Of Sammy Davis Jr." by Candy Mann
+"Feelings" by Cara Lott
+"Ecclesiastical Infractions" by Cardinal Sin
+"How To Tune Up Your Auto" by Carl Humm
+"Dinner's Ready!" by Carmen Gettit
+"Meat Eaters" by Carney Vore
+"Too Drunk to Walk" by Carrie Mee-Ohm
+"Singing Solo" by Carrie O'Kee
+"Life In The Sorority House" by Carrie Onn
+"Handsome, Charming, and..." by Cary Smattic
+"Boy Scout's Handbook" by Casey Needzit
+"We Take Credit Cards, But..." by Cassius Better
+"Jewish Egotists" by Chaim Wonderful
+"Obscure Cooking Aids" by Che Fingdish
+"Equine Leg Cramps" by Charlie Horse
+"Sofa so Good" by Chester Field
+"Classic Groceries" by Chopin Liszt
+"The Greasy Spoon" by Chris Coe
+"Perfect Cooking" by Chris P. Bacon A3
+"Mineralogy for Giants" by Chris Tall
+"What's For Dinner?" by Chuck Roast
+"Prayers For Children" by Cindy Skool
+"I Read You Like A Book" by Claire Voyant
+"Explaining it Better" by Clara Fie
+"Back Row Of The Orchestra" by Clara Nett
+"Shoes For Farm And Ranch" by Claude Hopper
+"Bobcat under the Bleachers" by Claude BottomsF
+"Destructive Cats" by Claude Sofa
+"The Lion Attacked" by Claudia Armoff
+"House Plants" by Clay Potts
+"Shaky Knees" by Cliff Diver
+"Boring Midwestern Cities" by Cole Lumbus
+"Take a Break!" by Colin Sick
+"Military Fast" by Colonel O'Corn
+"Pentagon Press Release" by Colonel O'Truth and Lotta Lies
+"The Sheet She Wore to the Party" by Connie Stoga
+"Does Not Prove Causation" by Cora Layshun
+"East Coast Universities" by Cora Nell
+"Flogging in the Army" by Corporal Punishment
+"Fortune Telling" by Crystal Ball
+"Paintings with Vegetables" by Currier Endives
+"Interior Decorating" by Curt Enrod
+"Nuts about You!" by Cy Cosis
+"Exercise on Wheels" by Cy Kling
+"Wooden Percussion" by Cy L'Phone
+"Solving Crimes" by D. Tective
+"Perry Mason's Last Case" by D. A. Zoffuss
+"The Senator" by D. C. Resident
+"Banned Pesticides" by D. D. Tee
+"I Swing for the Pitcher" by D. H. Batter
+"What I Dance To" by D. J. Music
+"Garlic Gone Bad" by D. K. Stinky
+"The World's Last Days" by D. N. Izneer
+"Didn't Make it to the Hospital" by D. O. Way
+"I Scream, You Scream..." by D. Q. Restaurant
+"The Drawbacks of Strong Drink" by D. T. Sufferer
+"I Got a New Car" by D. U. Care
+"How Sweet It Is" by D. X. Stacy
+"I Keep Falling Down" by D. Z. Person
+"We're All Flakes" by Dan Druff
+"Shhh!" by Danielle Soloud
+"Indiana Jones' Adventures" by Darrin Rescue
+"Tape Another Channel" by David E. O. Recorder
+"Great Tennis Matches" by Davis Skupp
+"A Boxing Cornerman's Story" by Dawson DeTowel
+"Fixing Computer Programs" by Dee Bugger
+"The Realm of the Dead" by Dee Seized
+"The Twelfth Month" by Dee Sember
+"Make Up Your Mind" by Dee Side
+"Racketeering" by Dennis Court
+"Suntanned Legs" by Denise R Brown
+"Baby Mess-Trappers" by Di Perrs
+"Webster's Words" by Dick Shunnary
+"Tyrant of the Potatoes" by Dick Tater
+"Fistfights" by Donny Brooke
+"Come on in!" by Doris Open
+"Life Six Feet Under" by Doug Graves
+"En Garde!" by Drew Blood
+"Poisonous Plants" by Dudley Nightshade
+"I Like Coffee" by Duncan Doughnuts
+"Housework" by Dustin Cook
+"Highway Travel" by Dusty Rhodes
+"Plumb Good" by Dwayne Pipe
+"Where's the Water?" by Dwayne Dwight Out
+"A Great Plenty" by E. Nuff
+"Cheer for Your Team!" by E. A. Hoo
+"Hard Cheese!" by E. Dam
+"How to Handle Nitroglycerine" by E. C. Duzzit
+"Circuit Analysis" by E. E. Major
+"Amazing Alphabet!" by E. F. Gee
+"Old Macdonald's Farm" by E. I. Eeyioh
+"Rodent in the House!" by E. K. Mouse
+"Ambition and Failure" by E. Peter. DoubtE
+"Science Fiction Stories" by E. T. Fonehome
+"How to be a Con Artist" by E. Z. Money
+"Christmas Dinner is Over at Last" by Ed Anuff
+"Revising my Work" by Eddie Torr
+"And so on and so forth" by Ed Nauseum
+"I Lost My Balance" by Eileen Dover and Phil Down
+"Fat Lady In The Sideshow" by Ellie Funt
+"How to Draw" by Ellis Strait
+"Confessions Of A Gold Digger" by Emile Ticket
+"I'm Scared!" by Emma Fraid
+"Columbus, Vespucci, And Me" by Enzo DiUrth
+"Why Tires aren't Flat" by Erin Side
+"Employment Handbook" by Ernie Living
+"She Saw Him" by Esau Her
+"I Like Liquor" by Ethel Alcohol
+"Turtle Racing" by Eubie Quick
+"Prepare To Meet Your Maker" by Eva DeStruction
+"Assault with Battery" by Eva Ready
+"Jello Proselytizing" by Evan Jellist
+"Boiled Dry" by Eve Aporate
+"Pull with All You've Got!" by Eve Ho
+"Fastest Gun In The West" by Everett DeReady
+"Investigating Optometrists" by F. B. Eye
+"Easy Listening" by F. M. Radio
+"Put Some Fizz Back In Your Life" by F. R. Vessant
+"Clever Replies" by F. U. Two
+"100 Pounds" by F. V. Load
+"Animal Scents" by Farrah Mones
+"Not Near" by Farrah Way
+"Look Younger" by Fay Slift
+"Raising Flowers By Hand" by Flo Wrist
+"Rangers In The Night" by Forrest Fyar
+"French Overpopulation" by Francis Crowded
+"Hot Dog!" by Frank Furter
+"To be Honest" by Frank Lee
+"I Say So!" by Frank O. Pinion
+"The Great Escape" by Freida Convict
+"Golly Gosh!" by G. Whiz
+"Bringing Good Things To Life" by G. E. Appliances
+"College for Soldiers" by G. I. Bill
+"Lousy American Cars" by G. M. Clunker
+"Republican Eliminations" by G. O. Pee
+"On The Cover" by G. Q. Model
+"Come On Mom, Pleeeeease?" by G. Y. Nott
+"I Hate Monday Mornings" by Gaetan Upp
+"Strong Winds" by Gail Force
+"Mensa Man" by Gene Yuss
+"Army Jokes" by General Hillary Tee
+"How to be a Vague Soldier" by General Lee
+"Gone With The Wind" by George Uh
+"Try, Try Again" by Getty Trite
+"I Wuz Framed!" by Gil Tee
+"Soda Pop History" by Ginger Aile
+"Hiya Fella" by Gladys Eeya
+"I Hate the Sun" by Gladys Knight
+"Scottish Kilt Patterns" by Glen Pladd
+"We Do Theft Cases" by Grabbitt & Run
+"The National Science Foundation" by Grant Money
+"Genie in a Bottle" by Grant Wishes
+"Put'er There, Pal!" by Greg Garious
+"Stomach Flu" by Gretchen Barf
+"Lawyers of Suffering" by Grin and Barrett
+"The World's Best Recipes" by Gus Tatorial
+"Laid Off!" by Gwen Home
+"Model Train Fanatics" by H. O. Scale
+"The Good Breakfast" by Hammond Deggs
+"Jewish Holidays" by Hannah Kuhh
+"Lazy Employees" by Hans Doolittle
+"The German Bank Robbery" by Hans Zupp
+"Get Moving, Slowpoke!" by Harriet Upp
+"Rapunzel, Rapunzel!" by Harris Long
+"Toupee Embarrassment" by Harrison Backwards
+"The Beach Bully" by Harry Ayp
+"At The Bottom Of The Can" by Hazel Nutt
+"Gangway!" by Hedda Steam
+"Cab Calloway's Garden" by Heidi Ho
+"I Lived in Detroit" by Helen Earth
+"Where the World is Going" by Helena Handbasket
+"In The Trenches" by Helmut Wearer
+"Greek Unbeliever!" by Hera Tick
+"A Bestiary of Plant Eaters" by Herb Avore
+"His Girl Thursday" by Herman Friday
+"Hunger In America" by Heywood Jafeedme
+"Funny Women" by Hillary Uss
+"Human Resources Manager" by Hiram N. Firem
+"Stunned Over Christmas" by Holly Daze
+"Tinseltown Tales" by Holly Wood
+"Poetry in Baseball" by Homer
+"Who Killed Cock Robin?" by Howard I. Know
+"I'm Fine" by Howard Yu
+"Chinese Apathy" by Hu Cares
+"Mystery in the Barnyard" by Hu Flung Dung
+"I Laugh at the Gods!" by Hugh Briss
+"Big Fart!" by Hugh Jass
+"Lots of Excitement" by Hugh N. Cry
+"Greeting Sheep Strangers" by Hugh R. Ewe
+"Parachuting" by Hugo First
+"Midnight Patrol" by Hugo Sair
+"No Camels Here!" by Humphrey Zoo
+"Computer Programming Made Easy" by I. B. Emm
+"Hazardous Driving" by I. C. Rhodes
+"I Lost at Hide-And-Seek" by I. C. U. Hiding
+"Well, I Never!" by I. D. Claire
+"I'm Not Getting Older, I'm Getting Better!" by I. H. Tenyears
+"How To Talk Good" by I. I. Stutter
+"Minor Infractions" by I. J. Walk
+"The Myth of the Mafia" by I. L. Killya
+"The Excitement of Trees" by I. M. Board
+"Loan Sharking Made Easy" by I. O. Yew
+"An Anthology of Children's Humor" by I. P. Dailey
+"Rusty Bedsprings" by I. P. Nightly
+"Mental Giants" by I. Q. Test
+"Hand It All Over!" by I. R. Ess
+"Desert Crossing" by I. Rhoda Camel
+"Fore!" by I. T. Off
+"Contraception" by I. U. Dee
+"Expensive Universities" by I. V. League
+"High Stakes Poker Tactics" by I. W. Betts JG5
+"Teach Me!" by I. Wanda Know
+"Bugs Beware!" by I. X. Terminate
+"Balancing Act" by I. Y. Yerr
+"The Garden State" by Ida Hoe
+"Let's Do it Now!" by Igor Beaver
+"Take This Job And Shove It" by Ike Witt
+"I'm Someone Else" by Ima Nonymous
+"The Phillipine Post Office" by Imelda Letter
+"Fred Can Philosophize!" by Immanuel Kant
+"No More Circuit Breakers!" by Ira Fuse
+"Cloning" by Irma Dubble II
+"What I Took" by Irv Erginity
+"In the Arctic Ocean" by Isa Berg
+"I Hit the Wall" by Isadore There
+"Why We Fall in Winter" by Isis Slippery
+"I Didn't Do It!" by Ivan Alibi
+"Mosquito Bites" by Ivan Itch
+"Russian Tennis Shoes" by Ivan Odor
+"My Seventh Husband" by Ivana Newhouse
+"Amnesia on Demand" by Ivor Gett
+"Cheating on His Wife" by Izzy Backyet
+"Can't Fence Me In!" by J. L. Breaker
+"A Critique of Ian Fleming" by J. M. Spond
+"Candle-Vaulting" by Jack B. Nimble
+"Fingerplay" by Jacob Sladder
+"Split Personalities" by Jacqueline Hyde
+"Don't Do Anything Rash" by Jacques Itch
+"Athletic Supporter" by Jacques Strap
+"The Dead Of Winter" by Jan Yuary
+"How to Clean Up Birdwatching" by Janet Oriole
+"Renowned Chefs" by Janice Cooks
+"Not Bogged Down In Reality" by Jason Rainbows
+"What Makes Airplanes Go" by Jeff Fuel
+"Hockey for Grandparents" by Jerry Hattrick
+"I Can Fix It" by Jerry Rigg
+"The Source of Electricity" by Jenny Rator
+"I Beat Bobby Fischer" by Jess Player
+"Birdwatching for Beginners" by Jesse the ParrotE
+"From the Great White North" by Jessica Nadian
+"Party On, Dude" by Jill Out
+"The Scent Of A Man" by Jim Nasium
+"Flips and Tumbles" by Jim Nastics
+"The Monkey Cage" by Jim Panzee
+"How to Break In" by Jimmy De Lock
+"Those Funny Dogs" by Joe Kur
+"How To Make Cornmeal Pancakes" by Johnny Cake
+"Star Spangled Barrio" by Jose Canusee
+"The Hitchhiker" by Juan Nalift
+"Two Thousand Pounds!" by Juan Ton
+"Personal Tutoring" by Juan Touwan
+"The Friendly Bartender" by Juana Beer
+"The Chuck Berry Story" by Judy Frudy
+"Life is a Trial" by Judd Gement
+"I Work with Diamonds" by Jules Sparkle
+"Options Trading" by June Gold
+"Look Ma, No Thumbs!" by Justice Fingers
+"I Need Insurance" by Justin Case
+"Almost Missed the Bus" by Justin Time
+"Poultry Farmers" by Justus Chickens
+"When Baseball Heros Strike Out" by K. C. Atbatt
+"Nothing to Chirp About" by K. D. Didd
+"How to Reply without Committing Yourself" by K. G. Answer
+"Bigots of America" by K. K. Kaye
+"How to Go Dutch on a Plane" by K. L. Emm
+"Hot Stuff!" by K. N. Pepper
+"I Coulda Been A Contender" by K. O. Boxer
+"A Thousand Potatoes Yet To Go" by K. P. Dooty
+"Working in a Nursing Home" by K. R. Giver
+"The Day All Heck Broke Loose" by K. T. Bardedoor
+"Slip-Slidin' Away" by K. Y. Jellee
+"The LA Lakers' Breakfast" by Kareem O'Wheat
+"Chirpin' and Jumpin'" by Katie Didd
+"After The Corned Beef And Cabbage" by Kay O'Pectate
+"Measles Collision!" by Kay Rash
+"Nuclear Power Bafflement" by Ken Fusion
+"Ex-Presidential Retreat" by Kenny Bunkport
+"A Stuntman To The End" by Kenny Doitt
+"Woulda Been A Great Shortstop" by Kent Hitt
+"Breaking the Law" by Kermit A. Krime
+"Don't Let Me Stop You" by Kerry Onn
+"Yoko's Robe" by Kim Ono
+"A Whole Lot of Cats" by Kitt N. Caboodle
+"The Economy is Recovering!" by Knott Quite
+"Pressure Relief" by Korsetsov
+"No" by Kurt Reply
+"Southern California Pachyderms" by L. A. Funt
+"The Terminator" by L. B. Back
+"Tennis Consequences" by L. Bow-Payne
+"History of Borden's Dairy Products" by L. C. DeCow
+"Illicit Sea Bird Activities" by L. E. Gull
+"Who Ate All the Cookies?" by L. F. Eyeno
+"If I Had The Chance" by L. I. Wood
+"The Role of the Hit Man" by L. M. Innate
+"Whose Face Can Launch 1000 Ships?" by L. N. OTroy
+"New In Town?" by L. O. Saylor
+"What Music Used to Be On" by L. P. Record
+"The Last Frontier" by L. S. Kah JG6
+"I Don't Believe This!" by L. U. Say
+"Anything on a Dare" by L. Y. Nott
+"Here's Pus In Your Eye" by Lance Boyle
+"Honest Citizen" by Laura Byder
+"Crackdown" by Lauren Order
+"Nobel Prize Cannibals" by Laurie Ate
+"Music of the Sea" by Lawrence Whelk
+"Tight Situation" by Leah Tard
+"More Mindless Violence" by Lee Fullweapon
+"You Drip!" by Lee K. Fawcette
+"The Palace Roof has a Hole" by Lee King
+"Nordic Groundskeepers" by Leif Raker
+"The Shrinking Society" by Les Ismoor
+"Bad Investment" by Les Riches
+"James Fenimore Cooper" by Lester Moe Hickens
+"Jewish Mysticism" by Lev Itation
+"Joys of Cowardice" by Lily Livard
+"Volunteer's Guidebook" by Linda Hand
+"Meals On Safari" by Lionel Eecha
+"Hertz, Don't It?" by Lisa Carr
+"Italian Delicacies" by Liz Onya
+"I Love Fractions" by Lois C. Denominator
+"How to Cut Grass" by Lon Moore
+"Scots in the Desert" by Lorna Dune
+"Punk Rock Rulez!" by Lotta Noyze
+"Good Housekeeping" by Lotta Dust
+"Mardi Gras Time" by Lou Isiana
+"Tear Up Those Betting Slips" by Lou Zerr
+"The Ham Radio Primer" by Loudon Clear
+"He's Contagious!" by Lucas Measles
+"Fallen Underwear" by Lucy Lastic
+"Tabletop Occultism" by Luigi Board
+"Danger!" by Luke Out
+"Not So Hot" by Luke Warm
+"Irish Flooring" by Lynn O'Leum
+"Now I'm in Business!" by M. B. Yay
+"How to Address an Audience" by M. C. Speaker
+"What's Up, Doc?" by M. D. Degree
+"Great Television Shows" by M. E. Awards
+"British Sports Cars" by M. G. Auto
+"On Her Majesty's Secret Service" by M. I. Five
+"Perverted Mushrooms" by M. Morel
+"How to Become Famous" by M. N. Ent
+"The Musical World of Walt Disney" by M. O. Yewessee
+"Enforcing Discipline in the Army" by M. P. Copps
+"Kingdom of the Flames" by M. Pyre
+"They're Not Cows" by M. R. Horses
+"How to Slow Down your Computer" by M. S. Windoze
+"Why Cars Stop" by M. T. Tank
+"Do as I Do, Not as I Say" by M. U. Late
+"Makeup for Thin People" by Mabel Leen
+"You're So Sweet" by Mable Syrup
+"Italian Cooking" by Mac Aroni
+"Round the World" by Madge Ellen
+"It's All In Your Head" by Madge Ination
+"Shamans and Witch Doctors" by Madison Menn
+"I Was a Cloakroom Attendant" by Mahatma Coate
+"Military Defeats" by Major Disaster and General Mayhem
+"I'm not a happy camper!" by Malcolm Tent
+"I Like Weeding Gardens" by Manuel Labour
+"Personal Best" by Marco DeStinction
+"The Truancy Problem" by Marcus Absent
+"Kangaroo Illnesses" by Marcus Wallaby, M.D.
+"Don’t Cry for Me" by Marge and Tina
+"Ship Mysteries" by Marie Celeste
+"Where to park your boat" by Marina Dock
+"Repent At Leisure" by Marion Hayste
+"Scuffed Floors" by Mark Tupp
+"Care For A Chop?" by Marsha Larts
+"Military Rule" by Marshall Law
+"Quips For The Young At Heart" by Marty Pants
+"Happy New Year!" by Mary Christmas
+"Nice Hotels" by Mary Ott
+"I Love Bullfighting" by Matt Adore
+"Fire Me Up!" by Matt Chez
+"Home Decorating" by Matt Emulsion
+"Scandinavian Photography" by Matt Finnish
+"Very Precise" by Matt Iculous
+"Weepy Movie" by Maud Lynn Story
+"The TV News Anchorman" by Maury Ports
+"More for Your Money" by Max Amize
+"Pilgrim Settlers" by May Flower
+"Continental Recipes" by May O'Nez
+"Riel Ambush!" by May T. Surprise
+"Computer Memories" by Meg Abight
+"It Won't Work!" by Mel Function
+"Irish Soap Operas" by Mel O'Drama
+"Caught in a Cyclone" by Mel Strom
+"Specialty Winemaker" by Merle O. Vintner
+"Overcoming Nervousness On Radio" by Mike Fright
+"Geez, It's Hot!" by Mike Hammeldyed
+"Clothes for Germ Kings" by Mike Robes
+"Daddy are We There Yet?" by Miles Away
+"When's The Revolution?" by Millie Tant
+"Decorating your Mousehole" by Minnie Blinds
+"Many Are Cold, But Few Are Frozen" by Minnie Sota
+"Long Walk" by Miss D. Bus
+"Errors and Accidents" by Miss Takes and Miss Haps
+"Car Capital Of The World" by Mitch Egan
+"Ohh, the Pain, the Pain!" by Moe N. Groan
+"Cut the Grass!" by Moe Lawn
+"The Porn Queen" by Mona Lott
+"Gambling" by Monty Carlos
+"Mexican Revenge" by Monty Zuma
+"No More Rifles!" by Morgan Control
+"I Love Crowds" by Morris Merrier
+"Cut the Grass!" by Moses Lawn
+"Wouldn't You Know It" by Murphy Slaw
+"French Cars" by Myra Neault k7
+"I Disagree With That!" by N. A. Sayer
+"History of Professional Basketball" by N. B. Yay
+"College Basketball in the South" by N. C. State
+"The Hoosier State" by N. D. Anna
+"I'm Not Choosy" by N. E. Buddy
+"History of Professional Football" by N. F. Ell
+"Medical Procedures" by N. G. OGram
+"Unsolved Mysteries" by N. Igma
+"Pain Killers" by N. L. Gesic
+"Have Fun at the Hospital!" by N. M. Uhh
+"Book Puns are a Nuisance" by N. O. Ying
+"You're Welcome" by N. Q. Verymuch
+"Everyone Needs a Gun!" by N. R. Ray
+"Hypnotism" by N. Tranced
+"Slam Dunk Champions" by N. U. Face
+"The Grass Is Always Greener" by N. V. Uss
+"Noise is Forbidden!" by Nada Loud
+"East Coast Resorts" by Nan Tuckett
+"American College Athletics" by Nancy Dubblelay
+"The Spiritual Life" by Ned Itation
+"Ready for Knighthood" by Neil Downe
+"Smoker's Cough" by Nick O'Teen
+"It's a Holdup!" by Nick R. Elastic
+"Dull Razor" by Nick Shaving
+"Political Correctness" by Noah Fence
+"My Lost Causes" by Noah Veil
+"The Great Flood" by Noah Zark
+"I'm an Atheist" by Noel Noheaven
+"Neither a Borrower" by Nora Lender Bee
+"Overweight Vegetables" by O. Beets
+"I'm Always Hungry" by O. B. City
+"Bad Trips" by O. D. Ondope
+"The Errant Sledgehammer" by O. G. Datturts
+"The White Flag" by O. I. Givupp
+"Better Than Concentrate" by O. J. Squeezer
+"The Good Employee" by O. K. Boss
+"I Dropped the Hammer" by O. L. Myfoot
+"First Aid for Kids" by O. O. Owie
+"Health Food Cereal" by O. T. Brann
+"Slang from the Roaring Twenties" by O. U. Kidd
+"You're Being Audited!" by O. Y. Mee
+"Swedish Perfumeries" by Ole Factory
+"The Peace Mission" by Olive Branch
+"Without Warning" by Oliver Sudden
+"Handel's Messiah" by Ollie Luyah
+"Surprised!" by Omar Gosh
+"The Empath" by Ophelia Sadness
+"Season Tickets" by Oprah Maven
+"Singin' and Shakin'" by Oprah Tic Tenor
+"Life Before Cars" by Orson Buggy
+"Pain in My Body" by Otis Leghurts
+"I Must Fix the Car!" by Otto Doit
+"The Industrial Revolution" by Otto Mattick
+"He Disappeared!" by Otto Sight
+"Money Management" by Owen Cash
+"And Now the Following Announcements" by P. A. System
+"Favourite Sandwiches" by P. B. Enjam
+"Cheaper than IBM" by P. C. Clone
+"Do It Now!" by P. D. Cue
+"Get In Shape!" by P. E. Class
+"No Children Please!" by P. G. Thirteen
+"We Solve Mysteries" by P. I. Detective
+"Favorite Sleepwear" by P. J. Bottoms
+"Light My Fire!" by P. K. Power (PK=Pyrokinesis)
+"First Step to French Fries" by P. L. Potatoes
+"How to Take Afternoon Naps" by P. M. Snooze
+"Tickling the Ivories" by P. N. Noe
+"The Urinalysis" by P. P. Inacupp
+"Eccentrics I Have Known" by P. Q. Lyirr
+"How to Deal with the Media" by P. R. Department
+"Early History of the Beatles" by P. S. Iluvya
+"Ships of the Navy" by P. T. Bote
+"Encounter with a Skunk" by P. U. Reek
+"What Makes Army People Sick" by P. X. Food
+"Skunks in the Shrubbery" by P. Yew
+"How to Read a Book" by Paige Turner
+"The Hidden Surprise" by Pam Perz
+"Preaching to Hell's Angels" by Pastor Redlight
+"What's Your Invention?" by Pat Tent
+"Green Lawn Chairs" by Patty O'Furniture
+"Grave Mistakes" by Paul Bearer
+"Foot Problems of Big Lumberjacks" by Paul Bunion
+"Tug of War" by Paul Hard
+"Maritime Rules" by Paula See
+"The Lady Pirate" by Peg Legg
+"Save Your Money" by Peggy Bank
+"The Miracle Drug" by Penny Cillin
+"Girl On a Budget" by Penny Pincher
+"Herbally Yours" by Penny Royal
+"Mexican/Italian Food" by Pepe Roney
+"Oppression of the Masses" by Percy Kyution
+"The Candy Store" by Pepper Mintz
+"Stop Harassing Me!" by Percy Kueshun
+"Irish Dentistry" by Perry O'Dontal
+"Events In The Soviet Union" by Perry Stroika
+"The Bog" by Pete Maas
+"In Farmer MacGregor's Garden" by Peter Abbott
+"Markings in the Sand" by Peter Dragon
+"Slowly Fades" by Peter Out A8
+"Home of the Liberty Bell" by Phil A. Delphia
+"The History Of Exxon" by Phil Errup
+"All About Orchestras" by Phil Harmonic
+"Exotic Irish Plants" by Phil O'Dendron
+"The Polarization Process" by Phil Terrout
+"Hollywood Gossip" by Phyllis Zinn
+"Artificial Clothing" by Polly Ester
+"Laughing In The White House" by Polly Tickle
+"How to Cook a Steak" by Porter House
+"Neat Shirts" by Preston Ironed
+"Keep 'Em That Way" by Private Parts
+"Find Another Lonely Heart" by Q. Pid
+"Why Software is Buggy" by Q. A. Tester
+"Proof Positive!" by Q. E. Dee
+"Carnival Prizes" by Q. P. Doll
+"Fashion Models" by Q. T. Pye
+"The Very Model of a Modern Major General" by Quinn Tessence
+"Third of Five" by Quinn Tuplet
+"Violate Me and Your Program Will Crash!" by R. A.Bounds
+"Encyclopedia of Poisons" by R. C. Nick
+"The Punny Book Title Collection Volume 8" by R. D. Harhar
+"See You In Phoenix!" by R. E. Zona
+"I Shot an Arrow In the Air" by R. G. Rhee
+"Sorry, You're Not My Type" by R. H. Factor
+"Covered Walkways" by R. Kade
+"Bring to the Grocer's" by R. List
+"It's All in the Wrist" by R. M. Wrestle
+"I Killed Cock Robin!" by R. S. T'Me
+"Where there are Hangings Every Day" by R. T. Museum
+"Irish First Aid" by R. U. O'Kaye
+"Where to Get a Road Hog" by R. V. Dealer
+"Junkyards of the World" by R. X. Taken
+"Bigotry" by Rachel Intolerance
+"How I Won The Marathon" by Randy Hoelway
+"Indian, Italian and Spanish Cuisine" by Ravi Oley
+"Lawn Care" by Ray King
+"Lewd Novels" by Ray See
+"How to Overcome Stress" by Ray Lachs
+"Chinese Stairs" by Ray Ling
+"Some Like It Hot" by Red Pepper
+"Formal List" by Reggie Stirr
+"The Fortuneteller" by Reid Palms
+"The Auto Salvage Business" by Rex Toad
+"Well-Spoken Predictions" by Rhett Oracle
+"Get to the Point!" by Rhonda Bout
+"I'm Exhausted!" by Rhonda Marathon
+"I Was A Son Of A Buccaneer" by Rich Kidd
+"Deflections" by Rick O'Shea
+"Weekend In Hong Kong" by Rick Shaw
+"Long Way Down" by Rip Cord Broke
+"How to Succeed in School" by Rita Book
+"Armed Heists" by Robin Banks
+"How to Tour the Prison" by Robin Steele
+"As Solid as..." by Rocco Gibraltar
+"Gone Fishing" by Rod Annette
+"Fish Story" by Rod Enreel
+"Okee Dokee" by Roger Wilco
+"Meeting Places" by Ron DeVoo
+"Go Away!" by Ron Onhome
+"Gardening With The Ex-President" by Rose Bush
+"Cosmetology" by Rosie Cheeks
+"What Geologists Study" by Roxanne Minerals
+"Wish I'd Never Been Born" by Rudy Daye
+"The Housing Problem" by Rufus Quick
+"Wind In The Maple Trees" by Russell Ingleaves
+"Small Vegetables" by Russell Sprout
+"The Squeaking Gate" by Rusty Hinges
+"Sandwich Making" by Ryan Mayo
+"Late Nights" by S. A. Due
+"Where She Sells Sea Shells" by S. C. Shore
+"Stories in the Future" by S. F. Writer
+"Will You Marry Me?" by S. I. Will
+"Whip Me into Shape" by S. M. Kinky
+"We all Need This!" by S. N. Shall
+"Compendium of Useless Tidbits" by S. O. Terrick
+"Spies Like Us" by S. P. O'Nage
+"The Fall of a Watermelon" by S. Platt
+"You Tell Me the Answer!" by S. Q. Question
+"Ginger vs. Mary Ann: You Decide!" by S. S. Minnow
+"Your Guess is as Good as Mine" by S. T. Mate
+"Living on the Land" by S. Tate
+"Great New York City Hotels" by S. X. House
+"Ready...Set..." by Sadie Word
+"Wake Up!" by Sal Ammoniac
+"Get Out There!" by Sally Forth
+"Latin Dances for Sheep" by Sam Baa
+"Still Looking For My Heart" by Sam Francisco
+"Imitating Mozart" by Sam Phony
+"I Can't See The Difference" by Sam Ting
+"Songs from 'South Pacific'" by Sam and Janet Evening
+"Dan Quayle's Englush Skils" by Sammy Literate
+"Summer Vacation" by Sandy and Shelley Beach
+"Southern California Waffles" by Sandy Eggo
+"Brane Surjery Maid Simpel" by Sarah Bellum
+"All Alone" by Saul E. Terry
+"Peeping Tom" by Sawyer Scanties
+"How To Beat A Murder Rap" by Scott Free
+"Holmes Does It Again" by Scott Linyard
+"Fancy Light Fixtures" by Sean D'Olier
+"Tailoring" by Serge Soote
+"Guarding the Door" by Sergeant Atarms
+"Joys of Septic Tanks" by Seth Poole JG9
+"Full Moon" by Seymour Buns
+"The Optician's Guide" by Seymour Clearly
+"Under the Bleachers" by Seymour Butts
+"Let's see That Again!" by Schlomo Replay
+"Rules For Living" by Sharon Sharalike
+"Get Moving!" by Sheik Aleg
+"You're Kidding!" by Shirley U. Jest
+"...And Shut Up!" by Sid Downe
+"Parting Shots" by Sid Semper Tyrannis
+"Circle Perimiter" by Sir Cumference
+"The Effects of Alcohol" by Sir Osis of Liver
+"Cough Medicine" by Sir Upp
+"Children's Songbook" by Skip Tumalu
+"Defunct Nations" by Sophie Etunion
+"Too Rough" by Soren Redd
+"The Senior Prom" by Spike Drink
+"Make your Marriage Work" by Stan Byerman
+"Life As A Comic" by Stan Dupp
+"West Coast Universities" by Stan Ford
+"Making Explosives" by Stan Wellback
+"NHL Hockey" by Stanley Kupp
+"The Telltale Heart" by Stefi Scope
+"Working on the Docks" by Steve Door
+"Manana" by Stew Layt
+"Things to Cook Meat In" by Stu Potts
+"The French Chef" by Sue Flay
+"The Big Wave" by Sue Nami
+"April Fool!" by Sue Prize
+"Waste Water" by Sue Ridgepipe
+"Some Like it Sweet" by Sugar Kane
+"Foot Coverings" by Susan Socks
+"It's Magic!" by Sven Gali
+"Sectarian Conflicts" by Sybil War
+"Why Must I Teach this Class?" by T. A. Blues
+"That Nagging Cough" by T. B. Carrier
+"Good Steak!" by T. Bone
+"Not Saved By The Bell!" by T. K. Ohh
+"It Aids Recovery" by T. L. See
+"Needed to Make the Hot Drinks" by T. Leaf
+"Explosive Beverages" by T. N. Tee
+"Dwelling Places of Some Native Americans" by T. P. Tent
+"Too Bad For You!" by T. S. Sucker
+"Golfer's Caffeine Source" by T. T. Hott
+"Quick and Hot" by T. V. Dinner
+"Revealing Secrets" by T. Zing
+"Little Bitty Froggies" by Tad Pole
+"Preparing Leather" by Tanya Hyde
+"Coin Tossing" by Taylor Hedd
+"Bad Cow Jokes" by Terry Bull
+"Talkative Japanese" by Terry Yaki
+"You Wash, I'll Dry" by Terry Cloth
+"Trial Law" by Tess Temoni
+"Sandpapers of the West" by Tex Ture
+"Who is She?" by Thad Gurl
+"Theft Among Arthropods" by The Lieutenants
+"What Mephistopheles Did" by Thelma Soul
+"Musical Gunfighters" by The Okay Chorale
+"The World's Deadliest Joke" by Theophilus Punoval
+"It's Springtime!" by Theresa Green
+"Whatchamacallit!" by Thingum Bob
+"Falling Trees" by Tim Burr
+"My Life on Skid Row" by Titus A. Drum
+"Off To Market" by Tobias A. Pigg
+"Keep them in Suspense" by Toby Continued
+"Battle Axes" by Tom A. Hawk
+"Wind Instruments" by Tom Bone and O. Bowe
+"Banquet at McDonalds" by Tommy Ayk
+"Chicago Gangs Of The '30's" by Tommy Gunn
+"Turkish Cattle" by Tristan Bull
+"Silly Rabbit" by Trixie R. Forkids
+"Ah, Thor!" by Ty Till
+"Do It Yourself" by Tyrone Shoelaces
+"Great Jazz Pianists" by U. B. Blake
+"Mortal Enemies" by U. I. Cantstand
+"London Bridge is Falling Down..." by U. K. Tourist
+"I Win!" by U. Lose
+"Talk Is Cheap" by U. N. Envoy
+"Income Tax Time" by U. O. Money
+"Believe it or Not" by U. R. Kidding
+"What's Green, Yet Does Not Grow?" by U. S. Dollar
+"Good for Nothing" by U. Sless
+"The Best of Elmer Fudd" by U. U. Wabbit
+"Red in the Face" by U. V. Index
+"Jokes for All Occasions" by U. Y. Sky
+"War Injuries I Have Seen" by V. A. Hospital
+"Embarrassing Infectious Diseases" by V. D. Clinic
+"Hitler's Beaten" by V. E. Daye
+"MacArthur's Triumph" by V. J. Daye
+"Dinner that Mooves You" by V. L. Scallopini
+"Compact Cars of the World" by V. W. Bugg
+"You're a Bundle of Laughs" by Vera Funny
+"Avoid that Pedestrian!" by Vera Way
+"Winning the Race" by Vic Tree
+"String Instruments" by Viola Player
+"New Computer Games" by Virgil Reality
+"Blowout!" by Vlad Tire
+"Web Browsing Made Easy" by W. W. Dotcom
+"Positive Reinforcement" by Wade Ago
+"Carpet Fitting" by Walter Wall
+"Judging Fast Food" by Warren Berger
+"Leo Tolstoy" by Warren Peace
+"Woman in Danger!" by Warner Quick
+"Downpour!" by Wayne Dwops
+"Life in Chicago" by Wendy City
+"That was Quick!" by Wendy Dothat
+"Exploring The Dutch Frontier" by Will Der Ness
+"Just Say No" by Will Power
+"Promises for Peace" by Will Shake and Mae Kupp
+"Fifty Yards to the Outhouse" by Willy Makit and Betty Woant
+"Social Insecurity" by Wilma Moneylast
+"Bad Gardeners" by Wilt Plant
+"Mobile Homes" by Winnie Bago
+"How to succeed at Craps" by Winona Seven
+"If I Invited Him..." by Woody Kum
+"Gunslingers with Gas" by Wyatt Urp
+"Engineering Instructor" by Wyatt Works
+"Be Your Best!" by X. L. Lent
+"Rash Decisions I Have Made" by X. M.
+"Hot Under the Collar" by X. O. Thermic
+"Hurry it Up!" by X. P. Dite
+"The Healthy Way to Lose Weight" by X. R. Size
+"Why Our Dumps are Filling Up" by X. S. Waste
+"The Greatest Pleasure" by X. T. See
+"Naughty Movies" by X. X. Ecks
+"Secrets of Dermatology" by X. Z. Mahh
+"Stop Arguing" by Xavier Breath
+"That Woman Gives Me Deja-Vu" by Xena Before
+"It's Unfair!" by Y. Me
+"The Wit and Wisdom of Chico Marx" by Y. A. Duck
+"Lose Weight Now" by Y. B. Phatt
+"Make the Ceiling Higher!" by Y. C. Stars
+"Beans for Breakfast" by Y. I. Toot
+"I Didn't Do It!" by Y. M. Eyehere
+"Trail Guide to Yellowstone Park" by Y. O. Ming
+"Get Up, Lazybones" by Y. R. Yewsleeping
+"The Sayings of Homer Simpson" by Y. U. Liddle
+"I Hurt Myself!" by Yin Pain
+"Playing with the Christmas Fire" by Yule B. Sari
+"Christmas for Baldies" by Yule Brynner
+"The Letter P" by Uri Nation
+"My Life in the Gutter" by Yves Trough
+"More Beard than Music" by Z. Z. Topp
+"It was Him!" by Zoe Didit

--- a/plugins/jokes.py
+++ b/plugins/jokes.py
@@ -39,11 +39,13 @@ def load_jokes(bot):
 
 
 @hook.command()
-def yomomma(text):
+def yomomma(text, nick, conn, is_nick_valid):
     """<nick> - Tells a yo momma joke to <nick>."""
     target = text.strip()
-    return '{}, {}'.format(target, random.choice(yo_momma).lower())
-
+    if not is_nick_valid(target) or target.lower() == conn.nick.lower():
+        target = nick
+    joke = random.choice(yo_momma).lower()
+    return '{}, {}'.format(target, joke)
 
 
 @hook.command(autohelp=False)

--- a/plugins/jokes.py
+++ b/plugins/jokes.py
@@ -1,8 +1,19 @@
-import codecs
-import os
 import random
+from pathlib import Path
 
 from cloudbot import hook
+
+
+def load_joke_file(path):
+    """
+    Loads all the lines from a file, excluding blanks and lines that have been 'commented out'.
+    :type path: Path
+    :rtype: List[str]
+    """
+    with path.open(encoding='utf-8') as f:
+        return [line.strip() for line in f
+                if line.strip()
+                and not line.startswith('//')]
 
 
 @hook.on_start()
@@ -12,32 +23,17 @@ def load_jokes(bot):
     """
     global yo_momma, do_it, pun, confucious, one_liner, wisdom, book_puns, lawyerjoke, kero_sayings
 
-    with codecs.open(os.path.join(bot.data_dir, "yo_momma.txt"), encoding="utf-8") as f:
-        yo_momma = [line.strip() for line in f.readlines() if not line.startswith("//")]
+    data_directory = Path(bot.data_dir)
 
-    with codecs.open(os.path.join(bot.data_dir, "do_it.txt"), encoding="utf-8") as f:
-        do_it = [line.strip() for line in f.readlines() if not line.startswith("//")]
-
-    with codecs.open(os.path.join(bot.data_dir, "puns.txt"), encoding="utf-8") as f:
-        pun = [line.strip() for line in f.readlines() if not line.startswith("//")]
-
-    with codecs.open(os.path.join(bot.data_dir, "confucious.txt"), encoding="utf-8") as f:
-        confucious = [line.strip() for line in f.readlines() if not line.startswith("//")]
-
-    with codecs.open(os.path.join(bot.data_dir, "one_liners.txt"), encoding="utf-8") as f:
-        one_liner = [line.strip() for line in f.readlines() if not line.startswith("//")]
-
-    with codecs.open(os.path.join(bot.data_dir, "wisdom.txt"), encoding="utf-8") as f:
-        wisdom = [line.strip() for line in f.readlines() if not line.startswith("//")]
-
-    with codecs.open(os.path.join(bot.data_dir, "book_puns.txt"), encoding="utf-8") as f:
-        book_puns = [line.strip() for line in f.readlines() if not line.startswith("//")]
-
-    with codecs.open(os.path.join(bot.data_dir, "lawyerjoke.txt"), encoding="utf-8") as f:
-        lawyerjoke = [line.strip() for line in f.readlines() if not line.startswith("//")]
-
-    with codecs.open(os.path.join(bot.data_dir, "kero.txt"), encoding="utf-8") as f:
-        kero_sayings = [line.strip() for line in f.readlines() if not line.startswith("//")]
+    yo_momma = load_joke_file(data_directory / 'yo_momma.txt')
+    do_it = load_joke_file(data_directory / 'do_it.txt')
+    pun = load_joke_file(data_directory / 'puns.txt')
+    confucious = load_joke_file(data_directory / 'confucious.txt')
+    one_liner = load_joke_file(data_directory / 'one_liners.txt')
+    wisdom = load_joke_file(data_directory / 'wisdom.txt')
+    book_puns = load_joke_file(data_directory / 'book_puns.txt')
+    lawyerjoke = load_joke_file(data_directory / 'lawyerjoke.txt')
+    kero_sayings = load_joke_file(data_directory / 'kero.txt')
 
 
 @hook.command()

--- a/plugins/jokes.py
+++ b/plugins/jokes.py
@@ -40,14 +40,15 @@ def load_jokes(bot):
 
 @hook.command()
 def yomomma(text):
-    """<nick> - tells a yo momma joke to <nick>"""
+    """<nick> - Tells a yo momma joke to <nick>."""
     target = text.strip()
     return '{}, {}'.format(target, random.choice(yo_momma).lower())
 
 
+
 @hook.command(autohelp=False)
 def doit(message):
-    """- prints a do it line, example: mathmaticians do with a pencil"""
+    """- Prints a do it line, example: mathematicians do with a pencil."""
     message(random.choice(do_it))
 
 
@@ -59,19 +60,21 @@ def pun(message):
 
 @hook.command(autohelp=False)
 def confucious(message):
-    """- confucious say man standing on toilet is high on pot."""
+    """- Confucious say man standing on toilet is high on pot.
+    (Note that the spelling is deliberate: https://www.urbandictionary.com/define.php?term=Confucious)
+    """
     message('Confucious say {}'.format(random.choice(confucious_say).lower()))
 
 
 @hook.command(autohelp=False)
 def dadjoke(message):
-    """- love em or hate em, bring on the dad jokes."""
+    """- Love em or hate em, bring on the dad jokes."""
     message(random.choice(one_liner))
 
 
 @hook.command(autohelp=False)
 def wisdom(message):
-    """- words of wisdom from various bathroom stalls."""
+    """- Words of wisdom from various bathroom stalls."""
     message(random.choice(wise_quotes))
 
 
@@ -87,7 +90,7 @@ def bookpun(message):
 
 @hook.command("boobs", "boobies")
 def boobies(text):
-    """- prints boobies!"""
+    """<text> - Everything is better with boobies!"""
     boob = "\u2299"
     out = text.strip()
     out = out.replace('o', boob).replace('O', boob).replace('0', boob)
@@ -98,14 +101,14 @@ def boobies(text):
 
 @hook.command("zombs", autohelp=False)
 def zombs():
-    """- prints some fucked up shit."""
+    """- Prints some fucked up shit."""
     out = "\u2299\u2299\u0505\u0F0D\u0020\u0E88\u0020\u25DE\u0C6A\u25DF\u0E88\u0020\u0F0D\u0648"
     return out
 
 
 @hook.command("awesome", "iscool", "cool")
 def awesome(text, is_nick_valid):
-    """- Prints a webpage to show <nick> how awesome they are."""
+    """<nick> - Prints a link to show <nick> how awesome they are."""
     link = 'http://is-awesome.cool/{}'
     nick = text.split(' ')[0]
     if is_nick_valid(nick):
@@ -118,7 +121,7 @@ def awesome(text, is_nick_valid):
 
 @hook.command(autohelp=False)
 def triforce(message):
-    """- returns a triforce!"""
+    """- Peturns a triforce!"""
     top = ["\u00a0\u25b2", "\u00a0\u00a0\u25b2", "\u25b2", "\u00a0\u25b2"]
     bottom = ["\u25b2\u00a0\u25b2", "\u25b2 \u25b2", "\u25b2\u25b2"]
     message(random.choice(top))
@@ -127,7 +130,7 @@ def triforce(message):
 
 @hook.command("kero", "kerowhack")
 def kero(text):
-    """- Returns the text input the way kerouac5 would say it."""
+    """<text> - Returns the text input the way kerouac5 would say it."""
     keror = random.choice(kero_sayings).upper()
     if keror == "???? WTF IS":
         out = keror + " " + text.upper()
@@ -138,11 +141,11 @@ def kero(text):
 
 @hook.command(autohelp=False)
 def lawyerjoke(message):
-    """- returns a lawyer joke, so lawyers know how much we hate them"""
+    """- Returns a lawyer joke, so lawyers know how much we hate them."""
     message(random.choice(lawyer_jokes))
 
 
 @hook.command("fuck", autohelp=False)
 def fuck():
-    """- returns something funny."""
+    """- Returns something funny."""
     return "something funny."

--- a/plugins/jokes.py
+++ b/plugins/jokes.py
@@ -88,10 +88,7 @@ def wisdom(message):
 def bookpun(message):
     """- Suggests a pun of a book title/author."""
     # suggestions = ["Why not try", "You should read", "You gotta check out"]
-    book = random.choice(joke_lines['book_puns'])
-    title = book.split(':')[0].strip()
-    author = book.split(':')[1].strip()
-    message("{} by {}".format(title, author))
+    message(random.choice(joke_lines['book_puns']))
 
 
 @hook.command("boobs", "boobies")

--- a/plugins/jokes.py
+++ b/plugins/jokes.py
@@ -101,7 +101,7 @@ def boobies(text):
     return out
 
 
-@hook.command("zombs", autohelp=False)
+@hook.command(autohelp=False)
 def zombs():
     """- Prints some fucked up shit."""
     out = "\u2299\u2299\u0505\u0F0D\u0020\u0E88\u0020\u25DE\u0C6A\u25DF\u0E88\u0020\u0F0D\u0648"
@@ -110,20 +110,19 @@ def zombs():
 
 @hook.command("awesome", "iscool", "cool")
 def awesome(text, is_nick_valid):
-    """<nick> - Prints a link to show <nick> how awesome they are."""
-    link = 'http://is-awesome.cool/{}'
-    nick = text.split(' ')[0]
-    if is_nick_valid(nick):
-        return "{}: I am blown away by your recent awesome action(s). Please read \x02{}\x02".format(
-            nick, link.format(nick)
-        )
-    else:
-        return "Sorry I can't tell {} how awesome they are.".format(nick)
+    """<nick> - Returns a link to show <nick> how awesome they are.
+    See https://github.com/sebastianbarfurth/is-awesome.cool
+    """
+    target = text.split(' ')[0]
+    if not is_nick_valid(target):
+        return "Sorry I can't tell {} how awesome they are.".format(target)
+    link = 'http://{}.is-awesome.cool/'.format(target)
+    return "{}: I am blown away by your recent awesome action(s). Please read \x02{}\x02".format(target, link)
 
 
 @hook.command(autohelp=False)
 def triforce(message):
-    """- Peturns a triforce!"""
+    """- Returns a triforce!"""
     top = ["\u00a0\u25b2", "\u00a0\u00a0\u25b2", "\u25b2", "\u00a0\u25b2"]
     bottom = ["\u25b2\u00a0\u25b2", "\u25b2 \u25b2", "\u25b2\u25b2"]
     message(random.choice(top))
@@ -147,7 +146,7 @@ def lawyerjoke(message):
     message(random.choice(lawyer_jokes))
 
 
-@hook.command("fuck", autohelp=False)
+@hook.command(autohelp=False)
 def fuck():
     """- Returns something funny."""
     return "something funny."

--- a/plugins/jokes.py
+++ b/plugins/jokes.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from cloudbot import hook
 
+yo_momma = do_it = puns = confucious_say = one_liner = wise_quotes = book_puns = lawyer_jokes = kero_sayings = ['']
+
 
 def load_joke_file(path):
     """
@@ -21,18 +23,18 @@ def load_jokes(bot):
     """
     :type bot: cloudbot.bot.Cloudbot
     """
-    global yo_momma, do_it, pun, confucious, one_liner, wisdom, book_puns, lawyerjoke, kero_sayings
+    global yo_momma, do_it, puns, confucious_say, one_liner, wise_quotes, book_puns, lawyer_jokes, kero_sayings
 
     data_directory = Path(bot.data_dir)
 
     yo_momma = load_joke_file(data_directory / 'yo_momma.txt')
     do_it = load_joke_file(data_directory / 'do_it.txt')
-    pun = load_joke_file(data_directory / 'puns.txt')
-    confucious = load_joke_file(data_directory / 'confucious.txt')
+    puns = load_joke_file(data_directory / 'puns.txt')
+    confucious_say = load_joke_file(data_directory / 'confucious.txt')
     one_liner = load_joke_file(data_directory / 'one_liners.txt')
-    wisdom = load_joke_file(data_directory / 'wisdom.txt')
+    wise_quotes = load_joke_file(data_directory / 'wisdom.txt')
     book_puns = load_joke_file(data_directory / 'book_puns.txt')
-    lawyerjoke = load_joke_file(data_directory / 'lawyerjoke.txt')
+    lawyer_jokes = load_joke_file(data_directory / 'lawyerjoke.txt')
     kero_sayings = load_joke_file(data_directory / 'kero.txt')
 
 
@@ -52,13 +54,13 @@ def doit(message):
 @hook.command(autohelp=False)
 def pun(message):
     """- Come on everyone loves puns right?"""
-    message(random.choice(pun))
+    message(random.choice(puns))
 
 
 @hook.command(autohelp=False)
 def confucious(message):
     """- confucious say man standing on toilet is high on pot."""
-    message('Confucious say {}'.format(random.choice(confucious).lower()))
+    message('Confucious say {}'.format(random.choice(confucious_say).lower()))
 
 
 @hook.command(autohelp=False)
@@ -70,7 +72,7 @@ def dadjoke(message):
 @hook.command(autohelp=False)
 def wisdom(message):
     """- words of wisdom from various bathroom stalls."""
-    message(random.choice(wisdom))
+    message(random.choice(wise_quotes))
 
 
 @hook.command(autohelp=False)
@@ -137,7 +139,7 @@ def kero(text):
 @hook.command(autohelp=False)
 def lawyerjoke(message):
     """- returns a lawyer joke, so lawyers know how much we hate them"""
-    message(random.choice(lawyerjoke))
+    message(random.choice(lawyer_jokes))
 
 
 @hook.command("fuck", autohelp=False)

--- a/plugins/jokes.py
+++ b/plugins/jokes.py
@@ -3,12 +3,11 @@ from pathlib import Path
 
 from cloudbot import hook
 
-yo_momma = do_it = puns = confucious_say = one_liner = wise_quotes = book_puns = lawyer_jokes = kero_sayings = ['']
+joke_lines = {}
 
 
 def load_joke_file(path):
-    """
-    Loads all the lines from a file, excluding blanks and lines that have been 'commented out'.
+    """Loads all the lines from a file, excluding blanks and lines that have been 'commented out'.
     :type path: Path
     :rtype: List[str]
     """
@@ -20,22 +19,26 @@ def load_joke_file(path):
 
 @hook.on_start()
 def load_jokes(bot):
-    """
+    """Load strings into memory from files in the data directory.
+    Put 'NAME.txt' in `file_list` to make those strings available as `joke_lines['NAME']`.
     :type bot: cloudbot.bot.Cloudbot
     """
-    global yo_momma, do_it, puns, confucious_say, one_liner, wise_quotes, book_puns, lawyer_jokes, kero_sayings
-
+    global joke_lines
     data_directory = Path(bot.data_dir)
-
-    yo_momma = load_joke_file(data_directory / 'yo_momma.txt')
-    do_it = load_joke_file(data_directory / 'do_it.txt')
-    puns = load_joke_file(data_directory / 'puns.txt')
-    confucious_say = load_joke_file(data_directory / 'confucious.txt')
-    one_liner = load_joke_file(data_directory / 'one_liners.txt')
-    wise_quotes = load_joke_file(data_directory / 'wisdom.txt')
-    book_puns = load_joke_file(data_directory / 'book_puns.txt')
-    lawyer_jokes = load_joke_file(data_directory / 'lawyerjoke.txt')
-    kero_sayings = load_joke_file(data_directory / 'kero.txt')
+    file_list = [
+        'yo_momma.txt',
+        'do_it.txt',
+        'puns.txt',
+        'confucious.txt',
+        'one_liners.txt',
+        'wisdom.txt',
+        'book_puns.txt',
+        'lawyerjoke.txt',
+        'kero.txt',
+    ]
+    for file_name in file_list:
+        file_path = data_directory / file_name
+        joke_lines[file_path.stem] = load_joke_file(file_path)
 
 
 @hook.command()
@@ -44,20 +47,20 @@ def yomomma(text, nick, conn, is_nick_valid):
     target = text.strip()
     if not is_nick_valid(target) or target.lower() == conn.nick.lower():
         target = nick
-    joke = random.choice(yo_momma).lower()
+    joke = random.choice(joke_lines['yo_momma']).lower()
     return '{}, {}'.format(target, joke)
 
 
 @hook.command(autohelp=False)
 def doit(message):
     """- Prints a do it line, example: mathematicians do with a pencil."""
-    message(random.choice(do_it))
+    message(random.choice(joke_lines['do_it']))
 
 
 @hook.command(autohelp=False)
 def pun(message):
     """- Come on everyone loves puns right?"""
-    message(random.choice(puns))
+    message(random.choice(joke_lines['puns']))
 
 
 @hook.command(autohelp=False)
@@ -65,26 +68,27 @@ def confucious(message):
     """- Confucious say man standing on toilet is high on pot.
     (Note that the spelling is deliberate: https://www.urbandictionary.com/define.php?term=Confucious)
     """
-    message('Confucious say {}'.format(random.choice(confucious_say).lower()))
+    saying = random.choice(joke_lines['confucious']).lower()
+    message('Confucious say {}'.format(saying))
 
 
 @hook.command(autohelp=False)
 def dadjoke(message):
     """- Love em or hate em, bring on the dad jokes."""
-    message(random.choice(one_liner))
+    message(random.choice(joke_lines['one_liners']))
 
 
 @hook.command(autohelp=False)
 def wisdom(message):
     """- Words of wisdom from various bathroom stalls."""
-    message(random.choice(wise_quotes))
+    message(random.choice(joke_lines['wisdom']))
 
 
 @hook.command(autohelp=False)
 def bookpun(message):
     """- Suggests a pun of a book title/author."""
     # suggestions = ["Why not try", "You should read", "You gotta check out"]
-    book = random.choice(book_puns)
+    book = random.choice(joke_lines['book_puns'])
     title = book.split(':')[0].strip()
     author = book.split(':')[1].strip()
     message("{} by {}".format(title, author))
@@ -132,7 +136,7 @@ def triforce(message):
 @hook.command("kero", "kerowhack")
 def kero(text):
     """<text> - Returns the text input the way kerouac5 would say it."""
-    keror = random.choice(kero_sayings).upper()
+    keror = random.choice(joke_lines['kero']).upper()
     if keror == "???? WTF IS":
         out = keror + " " + text.upper()
     else:
@@ -143,7 +147,7 @@ def kero(text):
 @hook.command(autohelp=False)
 def lawyerjoke(message):
     """- Returns a lawyer joke, so lawyers know how much we hate them."""
-    message(random.choice(lawyer_jokes))
+    message(random.choice(joke_lines['lawyerjoke']))
 
 
 @hook.command(autohelp=False)

--- a/plugins/jokes.py
+++ b/plugins/jokes.py
@@ -23,7 +23,6 @@ def load_jokes(bot):
     Put 'NAME.txt' in `file_list` to make those strings available as `joke_lines['NAME']`.
     :type bot: cloudbot.bot.Cloudbot
     """
-    global joke_lines
     data_directory = Path(bot.data_dir)
     file_list = [
         'yo_momma.txt',


### PR DESCRIPTION
I was motivated by the jokes plugin scoring an [*F* with codefactor.io](https://www.codefactor.io/repository/github/snoonetirc/cloudbot/file/gonzobot/plugins/jokes.py) to try and clean it up.
I refactored the `load_jokes` function, and renamed some of the global variables that conflicted with the command function names, which I hope bumps it up to an *A*.

While I was at it I went through the other command functions and freshened things up.
Consistent capitalization and punctuation. Some commands had an argument which wasn't in the doc-string. A handful of the functions were using the `message` parameter function when a simple return statement would do. Others redundantly declared a command name that was just the same as the function name.

The only functional changes are that `yomomma` now checks to make sure the target is a valid nick and not the bot itself (otherwise [the caller's nick gets used](https://i.imgur.com/kcLe9rY.gif))
and in `awesome` apparently the wrong link format was being used (I found a link to the source to hopefully aid future maintainers).