### PR TITLE
Add French-language weather support :fr:

### DIFF
--- a/plugins/weather.py
+++ b/plugins/weather.py
@@ -36,30 +36,28 @@ class GeocodeAPIError(Exception):
     def __str__(self):
         if self._status == 'REQUEST_DENIED':
             return 'The geocode API is off in the Google Developers Console.'
-        elif self._status == 'ZERO_RESULTS':
+        if self._status == 'ZERO_RESULTS':
             return 'No results found.'
-        elif self._status == 'OVER_QUERY_LIMIT':
+        if self._status == 'OVER_QUERY_LIMIT':
             return 'The geocode API quota has run out.'
-        elif self._status == 'UNKNOWN_ERROR':
+        if self._status == 'UNKNOWN_ERROR':
             return 'Unknown Error.'
-        elif self._status == 'INVALID_REQUEST':
+        if self._status == 'INVALID_REQUEST':
             return 'Invalid Request.'
-        else:
-            return repr(self._status)
+        return repr(self._status)
 
     def en_francais(self):
         if self._status == 'REQUEST_DENIED':
             return "L'API de géocodage est désactivée dans la console des développeurs Google."
-        elif self._status == 'ZERO_RESULTS':
+        if self._status == 'ZERO_RESULTS':
             return "Aucun resultat n'a été trouvé."
-        elif self._status == 'OVER_QUERY_LIMIT':
+        if self._status == 'OVER_QUERY_LIMIT':
             return "Le quota de API de géocodage est épuisé."
-        elif self._status == 'UNKNOWN_ERROR':
+        if self._status == 'UNKNOWN_ERROR':
             return 'Quelque chose a mal tourné.'
-        elif self._status == 'INVALID_REQUEST':
+        if self._status == 'INVALID_REQUEST':
             return 'Il y a eu une demande invalide.'
-        else:
-            return 'La France a été trahie! {!r}'.format(self._status)
+        return 'La France a été trahie! {!r}'.format(self._status)
 
 
 def find_location(location):


### PR DESCRIPTION
This addresses snoonetIRC/CloudBot#271

:warning: I have not been able to test that the new URL for the Weather Underground API works.
Apparently they are ending support for the API and no longer providing API keys.
According to [the documentation](https://www.wunderground.com/weather/api/d/docs?d=language-support) this should work though.

Since the Weather Underground API supports specifying a return language, the translation work locally is mostly swapping a few labels. While I like to think I know a little French, I relied entirely on Google Translate for this.

For the sake of completeness though, I also translated as many error messages as I could.

Also, at the prompting of my IDE, I added type information to doc-strings where it was missing.

Finally, the global `location_cache` was being kept as a list of key-value pairs and converted to a dict every time it was checked. Presumably there was a historical reason for this, but for now it seems more appropriate to just make it a dict.