### PR TITLE
Remove pytest-leaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - "pip install -r ./travis/requirements.txt"
 
 script:
-  - "py.test . -R : -v --cov . --cov-report term-missing --pylint --pylint-rcfile=travis/pylintrc"
+  - "py.test . -v --cov . --cov-report term-missing --pylint --pylint-rcfile=travis/pylintrc"
 
 after_success:
   - "coveralls"

--- a/travis/requirements.txt
+++ b/travis/requirements.txt
@@ -2,7 +2,6 @@ pytest==4.0.2
 responses==0.10.5
 pytest-cov==2.6.1
 pytest-pep8==1.0.6
-pytest-leaks==0.2.2
 pytest-travis-fold==1.3.0
 pytest-pylint==0.13.0
 flake8==3.6.0


### PR DESCRIPTION
This library hasn't been updated in years and is incompatible with
modern pytest