### PR TITLE
Fix return from help.py get_potential_commands

### DIFF
--- a/plugins/core/help.py
+++ b/plugins/core/help.py
@@ -13,7 +13,7 @@ def get_potential_commands(bot, cmd_name):
     """
     cmd_name = cmd_name.lower().strip()
     try:
-        yield bot.plugin_manager.commands[cmd_name]
+        yield cmd_name, bot.plugin_manager.commands[cmd_name]
     except LookupError:
         for name, _hook in bot.plugin_manager.commands.items():
             if name.startswith(cmd_name):


### PR DESCRIPTION
Erroroneously returned different types if a comamnd was found vs not
found