### PR TITLE
Refactored n_rolls function in the gaming plugin to be more readable

### DIFF
--- a/plugins/gaming.py
+++ b/plugins/gaming.py
@@ -37,23 +37,19 @@ def n_rolls(count, n):
     :type count: int
     :type n: int | str
     """
-    if n == "F":
+    if n in ('f', 'F'):
         return [random.randint(-1, 1) for _ in range(min(count, 100))]
 
-    if n < 2:  # it's a coin
-        if count < 100:
-            return [random.randint(0, 1) for _ in range(count)]
-
-        # fake it
-        return [int(random.normalvariate(.5 * count, (.75 * count) ** .5))]
-
-    if count < 100:
+    if n < 100:
         return [random.randint(1, n) for _ in range(count)]
 
-    # fake it
-    return [int(random.normalvariate(.5 * (1 + n) * count,
-                                     (((n + 1) * (2 * n + 1) / 6. -
-                                       (.5 * (1 + n)) ** 2) * count) ** .5))]
+    # Calculate a random sum approximated using a randomized normal variate with the midpoint used as the mu
+    # and an approximated standard deviation based on variance as the sigma
+    mid = .5 * (n + 1) * count
+    var = (n ** 2 - 1) / 12
+    adj_var = (var * count) ** 0.5
+
+    return [int(random.normalvariate(mid, adj_var))]
 
 
 @hook.command("roll", "dice")


### PR DESCRIPTION
The original code had several issues that have been addressed in this
commit. First, the function is never called from the coin function so
having this logic there is unnecessary and adding clutter. Second,
calculating the entire standard deviation as a single formula is
confusing and extremely hard to read and debug, so this was split
onto multiple lines. Finally, the method of calculating the variance
for use with the standard deviation was a longer and more roundabout
way of finding it. This was replaced with an equivalent but shorter
and more concise formula.

On branch gonzobot+gaming
Changes to be committed:
	modified:   plugins/gaming.py