### PR TITLE
Patches bug with bounds checking in .dice command

### DIFF
--- a/plugins/gaming.py
+++ b/plugins/gaming.py
@@ -40,7 +40,7 @@ def n_rolls(count, n):
     if n in ('f', 'F'):
         return [random.randint(-1, 1) for _ in range(min(count, 100))]
 
-    if n < 100:
+    if count < 100:
         return [random.randint(1, n) for _ in range(count)]
 
     # Calculate a random sum approximated using a randomized normal variate with the midpoint used as the mu


### PR DESCRIPTION
The wrong variable was being checked resulting in
simulating very large numbers rather than approximating
them. This patch fixes that.