### PR TITLE
Clean up etree XML parsing

### DIFF
--- a/cloudbot/util/http.py
+++ b/cloudbot/util/http.py
@@ -48,7 +48,11 @@ def get_soup(*args, **kwargs):
 
 def get_xml(*args, **kwargs):
     kwargs["decode"] = False  # we don't want to decode, for etree
-    return etree.fromstring(get(*args, **kwargs), parser=parser)
+    return parse_xml(get(*args, **kwargs))
+
+
+def parse_xml(text):
+    return etree.fromstring(text, parser=parser)  # nosec
 
 
 def get_json(*args, **kwargs):

--- a/plugins/steam_user.py
+++ b/plugins/steam_user.py
@@ -1,11 +1,8 @@
 import requests
-from lxml import etree
 
 from cloudbot import hook
 from cloudbot.util import formatting
-
-# security
-parser = etree.XMLParser(resolve_entities=False, no_network=True)
+from cloudbot.util.http import parse_xml
 
 API_URL = "http://steamcommunity.com/id/{}/"
 ID_BASE = 76561197960265728
@@ -66,7 +63,7 @@ def get_data(user):
     except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
         raise SteamError("Could not get user info: {}".format(e))
 
-    profile = etree.fromstring(request.content, parser=parser)
+    profile = parse_xml(request.content)
 
     try:
         data["name"] = profile.find('steamID').text

--- a/plugins/tvdb.py
+++ b/plugins/tvdb.py
@@ -1,13 +1,10 @@
 import datetime
 
 import requests
-from lxml import etree
 
 from cloudbot import hook
 from cloudbot.bot import bot
-
-# security
-parser = etree.XMLParser(resolve_entities=False, no_network=True)
+from cloudbot.util.http import parse_xml
 
 base_url = "http://thetvdb.com/api/"
 
@@ -24,7 +21,7 @@ def get_episodes_for_series(series_name, api_key):
         res["error"] = "error contacting thetvdb.com"
         return res
 
-    query = etree.fromstring(request.content, parser=parser)
+    query = parse_xml(request.content)
     series_id = query.xpath('//seriesid/text()')
 
     if not series_id:
@@ -40,7 +37,7 @@ def get_episodes_for_series(series_name, api_key):
         res["error"] = "error contacting thetvdb.com"
         return res
 
-    series = etree.fromstring(_request.content, parser=parser)
+    series = parse_xml(_request.content)
     try:
         series_name = series.xpath('//SeriesName/text()')[0]
     except LookupError:

--- a/plugins/wikipedia.py
+++ b/plugins/wikipedia.py
@@ -4,13 +4,10 @@ Scaevolus 2009"""
 import re
 
 import requests
-from lxml import etree
 
 from cloudbot import hook
 from cloudbot.util import formatting
-
-# security
-parser = etree.XMLParser(resolve_entities=False, no_network=True)
+from cloudbot.util.http import parse_xml
 
 api_prefix = "http://en.wikipedia.org/w/api.php"
 search_url = api_prefix + "?action=opensearch&format=xml"
@@ -30,7 +27,7 @@ def wiki(text, reply):
         reply("Could not get Wikipedia page: {}".format(e))
         raise
 
-    x = etree.fromstring(request.text, parser=parser)
+    x = parse_xml(request.text)
 
     ns = '{http://opensearch.org/searchsuggest2}'
     items = x.findall(ns + 'Section/' + ns + 'Item')

--- a/plugins/wolframalpha.py
+++ b/plugins/wolframalpha.py
@@ -2,14 +2,11 @@ import re
 import urllib.parse
 
 import requests
-from lxml import etree
 from requests import HTTPError
 
 from cloudbot import hook
 from cloudbot.util import web, formatting
-
-# security
-parser = etree.XMLParser(resolve_entities=False, no_network=True)
+from cloudbot.util.http import parse_xml
 
 api_url = 'http://api.wolframalpha.com/v2/query'
 query_url = 'http://www.wolframalpha.com/input/?i={}'
@@ -37,7 +34,7 @@ def wolframalpha(text, bot, reply):
     if request.status_code != requests.codes.ok:
         return "Error getting query: {}".format(request.status_code)
 
-    result = etree.fromstring(request.content, parser=parser)
+    result = parse_xml(request.content)
 
     # get the URL for a user to view this query in a browser
     short_url = web.try_shorten(query_url.format(urllib.parse.quote_plus(text)))


### PR DESCRIPTION
Replace multiple calls to etree.fromstring() with a global util function