### PR TITLE
Remove deprecated Event.async

### DIFF
--- a/cloudbot/event.py
+++ b/cloudbot/event.py
@@ -1,8 +1,6 @@
 import concurrent.futures
 import enum
 import logging
-import sys
-import warnings
 from functools import partial
 
 from irclib.parser import Message
@@ -352,7 +350,6 @@ class Event:
             return True
 
         for perm_hook in self.bot.plugin_manager.perm_hooks[permission]:
-            # noinspection PyTupleAssignmentBalance
             ok, res = await self.bot.plugin_manager.internal_launch(
                 perm_hook, self
             )
@@ -391,23 +388,6 @@ class Event:
             return getattr(self, item)
         except AttributeError:
             raise KeyError(item)
-
-    if sys.version_info < (3, 7, 0):
-        # noinspection PyCompatibility
-        async def async_(self, function, *args, **kwargs):
-            warnings.warn(
-                "event.async() is deprecated, use event.async_call() instead.",
-                DeprecationWarning, stacklevel=2
-            )
-            result = await self.async_call(function, *args, **kwargs)
-            return result
-
-
-# Silence deprecation warnings about use of the 'async' name as a function
-try:
-    setattr(Event, 'async', getattr(Event, 'async_'))
-except AttributeError:
-    pass
 
 
 class CommandEvent(Event):

--- a/cloudbot/plugin.py
+++ b/cloudbot/plugin.py
@@ -3,8 +3,6 @@ import importlib
 import inspect
 import logging
 import sys
-import time
-import warnings
 from collections import defaultdict
 from functools import partial
 from itertools import chain
@@ -672,14 +670,6 @@ class Hook:
 
         # don't process args starting with "_"
         self.required_args = [arg for arg in sig.parameters.keys() if not arg.startswith('_')]
-        if sys.version_info < (3, 7, 0):
-            if "async" in self.required_args:
-                logger.warning("Use of deprecated function 'async' in %s", self.description)
-                time.sleep(1)
-                warnings.warn(
-                    "event.async() is deprecated, use event.async_call() instead.",
-                    DeprecationWarning, stacklevel=2
-                )
 
         if asyncio.iscoroutine(self.function) or asyncio.iscoroutinefunction(self.function):
             self.threaded = False

--- a/tests/core_tests/test_plugin_hooks.py
+++ b/tests/core_tests/test_plugin_hooks.py
@@ -154,8 +154,6 @@ def test_hook_doc(hook):
 
 
 def test_hook_args(hook):
-    assert 'async' not in hook.required_args, "Use of deprecated function Event.async"
-
     bot = MockBot()
     if hook.type in ("irc_raw", "perm_check", "periodic", "on_start", "on_stop", "event", "on_connect"):
         event = Event(bot=bot)


### PR DESCRIPTION
This has been deprecated long enough and keeping it around really messes up the codebase