### PR TITLE
Only build main branches for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ branches:
   only:
   - gonzobot
   # Allow tagged releases in the format v1.0
-  - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+  - /^v\d+\.\d+.*$/
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ python:
   - "3.7"
   - "pypy3.5"
 
+branches:
+  only:
+  - gonzobot
+  # Allow tagged releases in the format v1.0
+  - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+
 cache: pip
 
 install:


### PR DESCRIPTION
We don't need to build branches like `dependabot/pip/...` and similar when they are also being built for PRs. We only really care about the main branch and tagged releases.