### PR TITLE
Add commands for factoid mass-removal

### DIFF
--- a/cloudbot/util/web.py
+++ b/cloudbot/util/web.py
@@ -59,7 +59,11 @@ def expand(url, service=None):
     return impl.expand(url)
 
 
-def paste(data, ext='txt', service=DEFAULT_PASTEBIN):
+class NoPasteException(Exception):
+    """No pastebins succeeded"""
+
+
+def paste(data, ext='txt', service=DEFAULT_PASTEBIN, raise_on_no_paste=False):
     bins = pastebins.copy()
     impl = bins.pop(service, None)
     while impl:
@@ -72,6 +76,9 @@ def paste(data, ext='txt', service=DEFAULT_PASTEBIN):
             _, impl = bins.popitem()
         except LookupError:
             impl = None
+
+    if raise_on_no_paste:
+        raise NoPasteException("Unable to paste data")
 
     return "Unable to paste data"
 

--- a/plugins/factoids.py
+++ b/plugins/factoids.py
@@ -7,10 +7,9 @@ from sqlalchemy import Table, Column, String, PrimaryKeyConstraint, and_
 from cloudbot import hook
 from cloudbot.util import database, colors, web
 from cloudbot.util.formatting import gen_markdown_table, get_text_list
-
-# below is the default factoid in every channel you can modify it however you like
 from cloudbot.util.web import NoPasteException
 
+# below is the default factoid in every channel you can modify it however you like
 default_dict = {"commands": "https://snoonet.org/gonzobot"}
 factoid_cache = defaultdict(default_dict.copy)
 
@@ -145,7 +144,6 @@ def remove_fact(chan, names, db, notice):
             return
 
         del_factoid(db, chan, list(found.keys()))
-
 
 
 @hook.command("f", "forget", permissions=["op", "chanop"])

--- a/tests/plugin_tests/test_factoids.py
+++ b/tests/plugin_tests/test_factoids.py
@@ -2,6 +2,7 @@ from textwrap import dedent
 
 import pytest
 from mock import patch, MagicMock, call
+from responses import RequestsMock
 
 
 def test_forget():
@@ -20,7 +21,36 @@ def patch_paste():
         yield mock
 
 
+def test_remove_fact_no_paste():
+    from plugins.factoids import factoid_cache
+    factoid_cache.clear()
+    with RequestsMock() as reqs:
+        reqs.add(reqs.POST, 'https://hastebin.com/documents', status=404)
+        mock_session = MagicMock()
+        mock_notice = MagicMock()
+
+        from plugins.factoids import remove_fact
+        remove_fact('#example', ['foo'], mock_session, mock_notice)
+        mock_notice.assert_called_once_with("Unknown factoids: 'foo'")
+
+        mock_session.execute.assert_not_called()
+
+        mock_notice.reset_mock()
+
+        factoid_cache['#example']['foo'] = 'bar'
+
+        remove_fact('#example', ['foo', 'bar'], mock_session, mock_notice)
+        mock_notice.assert_has_calls([
+            call("Unknown factoids: 'bar'"),
+            call('Unable to paste removed data, not removing facts'),
+        ])
+
+        mock_session.execute.assert_not_called()
+
+
 def test_remove_fact(patch_paste):
+    from plugins.factoids import factoid_cache
+    factoid_cache.clear()
     mock_session = MagicMock()
     mock_notice = MagicMock()
 
@@ -30,7 +60,6 @@ def test_remove_fact(patch_paste):
 
     mock_session.execute.assert_not_called()
 
-    from plugins.factoids import factoid_cache
     factoid_cache['#example']['foo'] = 'bar'
 
     patch_paste.return_value = "PASTEURL"

--- a/tests/plugin_tests/test_factoids.py
+++ b/tests/plugin_tests/test_factoids.py
@@ -1,0 +1,60 @@
+from textwrap import dedent
+
+from mock import patch, MagicMock, call
+
+
+def test_forget():
+    mock_session = MagicMock()
+    mock_notice = MagicMock()
+    with patch('plugins.factoids.remove_fact') as func:
+        from plugins.factoids import forget
+        forget('foo bar', '#example', mock_session, mock_notice)
+
+        func.assert_has_calls([
+            call('#example', 'foo', mock_session, mock_notice),
+            call('#example', 'bar', mock_session, mock_notice),
+        ])
+
+
+def test_remove_fact():
+    mock_session = MagicMock()
+    mock_notice = MagicMock()
+
+    from plugins.factoids import remove_fact
+    remove_fact('#example', 'foo', mock_session, mock_notice)
+    mock_notice.assert_called_with("Unknown fact 'foo'")
+
+    mock_session.execute.assert_not_called()
+
+    from plugins.factoids import factoid_cache
+    factoid_cache['#example']['foo'] = 'bar'
+
+    remove_fact('#example', 'foo', mock_session, mock_notice)
+    mock_notice.assert_called_with("'foo' has been forgotten, previous value was 'bar'")
+
+    query = mock_session.execute.mock_calls[0][1][0]
+
+    compiled = query.compile()
+
+    assert str(compiled) == dedent("""
+    DELETE FROM factoids WHERE factoids.chan = :chan_1 AND factoids.word = :word_1
+    """).strip()
+
+    assert compiled.params == {'chan_1': '#example', 'word_1': 'foo'}
+
+
+def test_clear_facts():
+    mock_session = MagicMock()
+
+    from plugins.factoids import forget_all
+    assert forget_all('#example', mock_session) == "Facts cleared."
+
+    query = mock_session.execute.mock_calls[0][1][0]
+
+    compiled = query.compile()
+
+    assert str(compiled) == dedent("""
+    DELETE FROM factoids WHERE factoids.chan = :chan_1
+    """).strip()
+
+    assert compiled.params == {'chan_1': '#example'}


### PR DESCRIPTION
- `forget` now accepts multiple names to delete
- `forgetall` allows a user to clear the entire facts list for a channel

Closes #461 