### PR TITLE
Clean up dynamic function attributes in tell_cmd

### DIFF
--- a/plugins/tell.py
+++ b/plugins/tell.py
@@ -328,12 +328,21 @@ def showtells(nick, notice, db, conn):
 
 
 @hook.command("tell")
-def tell_cmd(text, nick, db, notice, conn, notice_doc, is_nick_valid, mask):
-    """<nick> <message> - Relay <message> to <nick> when <nick> is around."""
+def tell_cmd(text, nick, db, conn, mask, event):
+    """<nick> <message> - Relay <message> to <nick> when <nick> is around.
+
+    :type text: str
+    :type nick: str
+    :type db: sqlalchemy.orm.Session
+    :type conn: cloudbot.client.Client
+    :type mask: str
+    :type event: cloudbot.event.CommandEvent
+    :rtype: None
+    """
     query = text.split(' ', 1)
 
     if len(query) != 2:
-        notice_doc()
+        event.notice_doc()
         return
 
     target = query[0]
@@ -341,23 +350,23 @@ def tell_cmd(text, nick, db, notice, conn, notice_doc, is_nick_valid, mask):
     sender = nick
 
     if not can_send_to_user(conn, mask, target):
-        notice("You may not send a tell to that user.")
+        event.notice("You may not send a tell to that user.")
         return
 
     if target.lower() == sender.lower():
-        notice("Have you looked in a mirror lately?")
+        event.notice("Have you looked in a mirror lately?")
         return
 
-    if not is_nick_valid(target.lower()) or target.lower() == conn.nick.lower():
-        notice("Invalid nick '{}'.".format(target))
+    if not event.is_nick_valid(target.lower()) or target.lower() == conn.nick.lower():
+        event.notice("Invalid nick '{}'.".format(target))
         return
 
     if count_unread(db, conn.name, target.lower()) >= 10:
-        notice("Sorry, {} has too many messages queued already.".format(target))
+        event.notice("Sorry, {} has too many messages queued already.".format(target))
         return
 
     add_tell(db, conn.name, sender, target.lower(), message)
-    notice("Your message has been saved, and {} will be notified once they are active.".format(target))
+    event.notice("Your message has been saved, and {} will be notified once they are active.".format(target))
 
 
 def check_permissions(event, *perms):

--- a/tests/plugin_tests/test_tell.py
+++ b/tests/plugin_tests/test_tell.py
@@ -1,0 +1,142 @@
+import importlib
+
+from irclib.parser import Prefix
+from mock import MagicMock, patch
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+Session = scoped_session(sessionmaker())
+
+
+def test_tellcmd():
+    from cloudbot.util import database
+    from plugins import tell
+    database = importlib.reload(database)
+    tell = importlib.reload(tell)
+    metadata = database.metadata
+
+    assert 'tells' in metadata.tables
+    assert 'tell_ignores' in metadata.tables
+    assert 'tell_user_ignores' in metadata.tables
+
+    db_engine = create_engine('sqlite:///:memory:')
+    Session.configure(bind=db_engine)
+    metadata.create_all(db_engine)
+    session = Session()
+    tell.load_cache(session)
+    tell.load_disabled(session)
+    tell.load_ignores(session)
+
+    mock_event = MagicMock()
+    mock_event.is_nick_valid.return_value = True
+    mock_conn = MagicMock()
+    mock_conn.nick = "BotNick"
+    mock_conn.name = "MockConn"
+    sender = Prefix("TestUser", "user", "example.com")
+    tell.tell_cmd(
+        "OtherUser",
+        sender.nick,
+        session,
+        mock_conn,
+        sender.mask,
+        mock_event,
+    )
+
+    mock_event.notice_doc.assert_called_once_with()
+
+    mock_event.reset_mock()
+
+    tell.tell_cmd(
+        "OtherUser some message",
+        sender.nick,
+        session,
+        mock_conn,
+        sender.mask,
+        mock_event,
+    )
+
+    mock_event.notice.assert_called_with(
+        "Your message has been saved, and OtherUser will be notified once they are active."
+    )
+
+    mock_event.reset_mock()
+
+    for _ in range(9):
+        tell.tell_cmd(
+            "OtherUser some message",
+            sender.nick,
+            session,
+            mock_conn,
+            sender.mask,
+            mock_event,
+        )
+
+        mock_event.notice.assert_called_with(
+            "Your message has been saved, and OtherUser will be notified once they are active."
+        )
+
+        mock_event.reset_mock()
+
+    tell.tell_cmd(
+        "OtherUser some message",
+        sender.nick,
+        session,
+        mock_conn,
+        sender.mask,
+        mock_event,
+    )
+
+    mock_event.notice.assert_called_with(
+        "Sorry, OtherUser has too many messages queued already."
+    )
+
+    mock_event.reset_mock()
+
+    mock_event.is_nick_valid.return_value = False
+    tell.tell_cmd(
+        "OtherUser some message",
+        sender.nick,
+        session,
+        mock_conn,
+        sender.mask,
+        mock_event,
+    )
+
+    mock_event.notice.assert_called_with(
+        "Invalid nick 'OtherUser'."
+    )
+
+    mock_event.reset_mock()
+
+    mock_event.is_nick_valid.return_value = True
+    tell.tell_cmd(
+        sender.nick + " some message",
+        sender.nick,
+        session,
+        mock_conn,
+        sender.mask,
+        mock_event,
+    )
+
+    mock_event.notice.assert_called_with(
+        "Have you looked in a mirror lately?"
+    )
+
+    mock_event.reset_mock()
+
+    with patch('plugins.tell.can_send_to_user') as mocked:
+        mocked.return_value = False
+        tell.tell_cmd(
+            "OtherUser some message",
+            sender.nick,
+            session,
+            mock_conn,
+            sender.mask,
+            mock_event,
+        )
+
+        mock_event.notice.assert_called_with(
+            "You may not send a tell to that user."
+        )
+
+        mock_event.reset_mock()

--- a/tests/plugin_tests/test_tell.py
+++ b/tests/plugin_tests/test_tell.py
@@ -33,6 +33,21 @@ def test_tellcmd():
     mock_conn.nick = "BotNick"
     mock_conn.name = "MockConn"
     sender = Prefix("TestUser", "user", "example.com")
+
+    def _test(text, output):
+        tell.tell_cmd(
+            text,
+            sender.nick,
+            session,
+            mock_conn,
+            sender.mask,
+            mock_event,
+        )
+
+        mock_event.notice.assert_called_with(output)
+
+        mock_event.reset_mock()
+
     tell.tell_cmd(
         "OtherUser",
         sender.nick,
@@ -46,97 +61,38 @@ def test_tellcmd():
 
     mock_event.reset_mock()
 
-    tell.tell_cmd(
+    _test(
         "OtherUser some message",
-        sender.nick,
-        session,
-        mock_conn,
-        sender.mask,
-        mock_event,
-    )
-
-    mock_event.notice.assert_called_with(
         "Your message has been saved, and OtherUser will be notified once they are active."
     )
 
-    mock_event.reset_mock()
-
     for _ in range(9):
-        tell.tell_cmd(
+        _test(
             "OtherUser some message",
-            sender.nick,
-            session,
-            mock_conn,
-            sender.mask,
-            mock_event,
-        )
-
-        mock_event.notice.assert_called_with(
             "Your message has been saved, and OtherUser will be notified once they are active."
         )
 
-        mock_event.reset_mock()
-
-    tell.tell_cmd(
+    _test(
         "OtherUser some message",
-        sender.nick,
-        session,
-        mock_conn,
-        sender.mask,
-        mock_event,
-    )
-
-    mock_event.notice.assert_called_with(
         "Sorry, OtherUser has too many messages queued already."
     )
 
-    mock_event.reset_mock()
-
     mock_event.is_nick_valid.return_value = False
-    tell.tell_cmd(
-        "OtherUser some message",
-        sender.nick,
-        session,
-        mock_conn,
-        sender.mask,
-        mock_event,
-    )
 
-    mock_event.notice.assert_called_with(
+    _test(
+        "OtherUser some message",
         "Invalid nick 'OtherUser'."
     )
 
-    mock_event.reset_mock()
-
     mock_event.is_nick_valid.return_value = True
-    tell.tell_cmd(
+    _test(
         sender.nick + " some message",
-        sender.nick,
-        session,
-        mock_conn,
-        sender.mask,
-        mock_event,
-    )
-
-    mock_event.notice.assert_called_with(
         "Have you looked in a mirror lately?"
     )
 
-    mock_event.reset_mock()
-
     with patch('plugins.tell.can_send_to_user') as mocked:
         mocked.return_value = False
-        tell.tell_cmd(
+        _test(
             "OtherUser some message",
-            sender.nick,
-            session,
-            mock_conn,
-            sender.mask,
-            mock_event,
-        )
-
-        mock_event.notice.assert_called_with(
             "You may not send a tell to that user."
         )
-
-        mock_event.reset_mock()


### PR DESCRIPTION
Type checking for passed method references is hard, passing the base
event, annotating the type, and accessing the methods from there allows
for better type checks