### PR TITLE
Handle metars api 404

### DIFF
--- a/plugins/metars.py
+++ b/plugins/metars.py
@@ -12,6 +12,9 @@ def lookup(text, url):
         return "please specify a valid station code see http://weather.rap.ucar.edu/surface/stations.txt for a list."
 
     request = requests.get(url + station)
+    if request.status_code == 404:
+        return "Station not found"
+
     request.raise_for_status()
     r = request.json()['reports'][0]
     out = r['name'] + ": " + r['raw_text']


### PR DESCRIPTION
When a station isn't found, inform the user and eat the 404 exception