### PR TITLE
core/bot.py: Only return the first prefix for triggered_prefix

### DIFF
--- a/cloudbot/bot.py
+++ b/cloudbot/bot.py
@@ -352,7 +352,7 @@ class CloudBot:
 
             if cmd_match:
                 command_prefix = event.conn.config.get('command_prefix', '.')
-                prefix = cmd_match.group('prefix') or command_prefix
+                prefix = cmd_match.group('prefix') or command_prefix[0]
                 command = cmd_match.group('command').lower()
                 text = cmd_match.group('text').strip()
                 cmd_event = partial(


### PR DESCRIPTION
If a command is fired by doing <botnick>: command, the prefix isn't set
and falls back to what is defined in the config. This uses the first
character of that instead so multiple prefixes still just show one.

Fixes #487 