### PR TITLE
lastfm: Add more error info if the JSON is invalid

### DIFF
--- a/plugins/lastfm.py
+++ b/plugins/lastfm.py
@@ -91,7 +91,11 @@ def api_request(method, **params):
     try:
         data = request.json()
     except JSONDecodeError:
+        # Raise an exception if the HTTP request returned an error
         request.raise_for_status()
+
+        # If raise_for_status() doesn't raise an exception, just re-reraise the
+        # existing error
         raise
 
     if 'error' in data:

--- a/plugins/lastfm.py
+++ b/plugins/lastfm.py
@@ -1,6 +1,7 @@
 import math
 import string
 from datetime import datetime
+from json import JSONDecodeError
 
 import requests
 from sqlalchemy import Table, Column, PrimaryKeyConstraint, String
@@ -87,7 +88,12 @@ def api_request(method, **params):
     params.update({"method": method, "api_key": api_key})
     request = requests.get(api_url, params=params)
 
-    data = request.json()
+    try:
+        data = request.json()
+    except JSONDecodeError:
+        request.raise_for_status()
+        raise
+
     if 'error' in data:
         return data, "Error: {}.".format(data["message"])
 

--- a/tests/plugin_tests/test_lastfm.py
+++ b/tests/plugin_tests/test_lastfm.py
@@ -1,0 +1,56 @@
+from json import JSONDecodeError
+
+import pytest
+import requests
+from requests import HTTPError
+from responses import RequestsMock
+
+from cloudbot.bot import bot
+from cloudbot.config import Config
+from plugins.lastfm import api_request
+
+
+class MockConfig(Config):
+    def load_config(self):
+        self._api_keys.clear()
+
+
+class MockBot:
+    def __init__(self, config):
+        self.config = MockConfig(self, config)
+
+
+def test_api():
+    bot.set(MockBot({"api_keys": {"lastfm": "hunter20"}}))
+
+    with RequestsMock() as reqs:
+        with pytest.raises(requests.ConnectionError):
+            api_request('track.getTopTags')
+
+        reqs.add(
+            reqs.GET, "http://ws.audioscrobbler.com/2.0/",
+            json={"data": "thing"}
+        )
+
+        res, _ = api_request('track.getTopTags')
+
+        assert res["data"] == "thing"
+
+    with RequestsMock() as reqs:
+        reqs.add(
+            reqs.GET, "http://ws.audioscrobbler.com/2.0/",
+            body="<html></html>"
+        )
+
+        with pytest.raises(JSONDecodeError):
+            api_request("track.getTopTags")
+
+    with RequestsMock() as reqs:
+        reqs.add(
+            reqs.GET, "http://ws.audioscrobbler.com/2.0/",
+            body="<html></html>",
+            status=403
+        )
+
+        with pytest.raises(HTTPError):
+            api_request("track.getTopTags")


### PR DESCRIPTION
If the web server returns a non-JSON response, the only error reported
is a decode error, this makes it so decode errors will trigger
.raise_for_status() as well, which will log all relevant information